### PR TITLE
Adjustments to jumping/wall-jumping / The spinner has been changed to allow use by Mega Mario and is less strict on the blue shell powerup

### DIFF
--- a/Assets/Resources/Prefabs/PlayerLuigi.prefab
+++ b/Assets/Resources/Prefabs/PlayerLuigi.prefab
@@ -21824,8 +21824,8 @@ MonoBehaviour:
   dead: 0
   state: 0
   previousState: 0
-  slowriseGravity: 0.85
-  normalGravity: 2.5
+  slowriseGravity: 1.15
+  normalGravity: 3.25
   flyingGravity: 0.8
   flyingTerminalVelocity: 1.25
   drillVelocity: 7
@@ -21833,14 +21833,14 @@ MonoBehaviour:
   groundpoundVelocity: 10
   blinkingSpeed: 0.25
   terminalVelocity: -7
-  jumpVelocity: 6.25
+  jumpVelocity: 7
   launchVelocity: 12
   walkingAcceleration: 8
   runningAcceleration: 3
   walkingMaxSpeed: 2.7
   runningMaxSpeed: 5
   wallslideSpeed: -4.25
-  walljumpVelocity: 5.6
+  walljumpVelocity: 6.25
   giantStartTime: 1.5
   soundRange: 10
   slopeSlidingAngle: 25
@@ -21880,6 +21880,7 @@ MonoBehaviour:
   iceSliding: 0
   stuckInBlock: 0
   propeller: 0
+  usedPropellerThisJump: 0
   frozen: 0
   walljumping: 0
   landing: 0
@@ -21894,10 +21895,12 @@ MonoBehaviour:
   giantEndTimer: 0
   propellerTimer: 0
   propellerSpinTimer: 0
-  frozenJump: 0
+  frozenStruggle: 0
   invincible: 0
   giantTimer: 0
   floorAngle: 0
+  knockbackTimer: 0
+  unfreezeTimer: 0
   pipeDirection: {x: 0, y: 0}
   stars: 0
   coins: 0
@@ -21945,6 +21948,8 @@ MonoBehaviour:
   smallAvatar: {fileID: 9000000, guid: e0d3ef6bcff32414dbd34fc6ac031292, type: 3}
   largeAvatar: {fileID: 9000000, guid: 024ceb223bceebd488dbc425555f4df0, type: 3}
   glowColor: {r: 0, g: 0, b: 0, a: 0}
+  primaryColor: {r: 0, g: 0, b: 0, a: 0}
+  secondaryColor: {r: 0, g: 0, b: 0, a: 0}
   normalDrill: {fileID: 8300000, guid: 80e6fe6f66166f04e8beccc08fe56422, type: 3}
   propellerDrill: {fileID: 8300000, guid: c8ae9349c885145468011889cafc470b, type: 3}
 --- !u!50 &8636928217783201367
@@ -22238,6 +22243,12 @@ MonoBehaviour:
   - Type: 4
     SynchronizeType: 2
     Name: fireballKnockback
+  - Type: 4
+    SynchronizeType: 0
+    Name: knockforwards
+  - Type: 4
+    SynchronizeType: 0
+    Name: head carry
   m_SynchronizeLayers:
   - SynchronizeType: 0
     LayerIndex: 0
@@ -22310,6 +22321,7 @@ MonoBehaviour:
   dampingTime: 0.5
   screenShakeTimer: 0
   exactCentering: 0
+  controlCamera: 0
   offset: {x: 0, y: 0, z: 0}
   currentPosition: {x: 0, y: 0, z: 0}
 --- !u!114 &3651738984749022226

--- a/Assets/Resources/Prefabs/PlayerMario.prefab
+++ b/Assets/Resources/Prefabs/PlayerMario.prefab
@@ -10198,8 +10198,8 @@ MonoBehaviour:
   dead: 0
   state: 0
   previousState: 0
-  slowriseGravity: 0.85
-  normalGravity: 2.5
+  slowriseGravity: 1.15
+  normalGravity: 3.25
   flyingGravity: 0.8
   flyingTerminalVelocity: 1.25
   drillVelocity: 7
@@ -10207,14 +10207,14 @@ MonoBehaviour:
   groundpoundVelocity: 10
   blinkingSpeed: 0.25
   terminalVelocity: -7
-  jumpVelocity: 6.25
+  jumpVelocity: 7
   launchVelocity: 12
   walkingAcceleration: 8
   runningAcceleration: 3
   walkingMaxSpeed: 2.7
   runningMaxSpeed: 5
   wallslideSpeed: -4.25
-  walljumpVelocity: 5.6
+  walljumpVelocity: 6.25
   giantStartTime: 1.5
   soundRange: 10
   slopeSlidingAngle: 25
@@ -10623,9 +10623,6 @@ MonoBehaviour:
   - Type: 4
     SynchronizeType: 1
     Name: knockforwards
-  - Type: 9
-    SynchronizeType: 0
-    Name: propellerStart
   m_SynchronizeLayers:
   - SynchronizeType: 0
     LayerIndex: 0

--- a/Assets/Resources/Prefabs/PlayerToadette.prefab
+++ b/Assets/Resources/Prefabs/PlayerToadette.prefab
@@ -4891,8 +4891,8 @@ MonoBehaviour:
   dead: 0
   state: 0
   previousState: 0
-  slowriseGravity: 0.85
-  normalGravity: 2.5
+  slowriseGravity: 1.15
+  normalGravity: 3.25
   flyingGravity: 0.8
   flyingTerminalVelocity: 1.25
   drillVelocity: 7
@@ -4900,14 +4900,14 @@ MonoBehaviour:
   groundpoundVelocity: 10
   blinkingSpeed: 0.25
   terminalVelocity: -7
-  jumpVelocity: 6.25
+  jumpVelocity: 7
   launchVelocity: 12
   walkingAcceleration: 8
   runningAcceleration: 3
   walkingMaxSpeed: 2.7
   runningMaxSpeed: 5
   wallslideSpeed: -4.25
-  walljumpVelocity: 5.6
+  walljumpVelocity: 6.25
   giantStartTime: 1.5
   soundRange: 10
   slopeSlidingAngle: 25
@@ -4962,10 +4962,12 @@ MonoBehaviour:
   giantEndTimer: 0
   propellerTimer: 0
   propellerSpinTimer: 0
-  frozenJump: 0
+  frozenStruggle: 0
   invincible: 0
   giantTimer: 0
   floorAngle: 0
+  knockbackTimer: 0
+  unfreezeTimer: 0
   pipeDirection: {x: 0, y: 0}
   stars: 0
   coins: 0
@@ -5013,6 +5015,8 @@ MonoBehaviour:
   smallAvatar: {fileID: 9000000, guid: e0d3ef6bcff32414dbd34fc6ac031292, type: 3}
   largeAvatar: {fileID: 9000000, guid: 024ceb223bceebd488dbc425555f4df0, type: 3}
   glowColor: {r: 0, g: 0, b: 0, a: 0}
+  primaryColor: {r: 0, g: 0, b: 0, a: 0}
+  secondaryColor: {r: 0, g: 0, b: 0, a: 0}
   normalDrill: {fileID: 8300000, guid: 80e6fe6f66166f04e8beccc08fe56422, type: 3}
   propellerDrill: {fileID: 8300000, guid: c8ae9349c885145468011889cafc470b, type: 3}
 --- !u!50 &1798796769927389753
@@ -5309,9 +5313,6 @@ MonoBehaviour:
   - Type: 4
     SynchronizeType: 1
     Name: knockforwards
-  - Type: 9
-    SynchronizeType: 1
-    Name: propellerStart
   - Type: 4
     SynchronizeType: 1
     Name: firedeath
@@ -5387,6 +5388,7 @@ MonoBehaviour:
   dampingTime: 0.5
   screenShakeTimer: 0
   exactCentering: 0
+  controlCamera: 0
   offset: {x: 0, y: 0, z: 0}
   currentPosition: {x: 0, y: 0, z: 0}
 --- !u!114 &3494046117617009192

--- a/Assets/Scripts/Entity/Player/PlayerAnimationController.cs
+++ b/Assets/Scripts/Entity/Player/PlayerAnimationController.cs
@@ -77,7 +77,7 @@ public class PlayerAnimationController : MonoBehaviourPun {
                     targetEuler = new Vector3(0, 100, 0);
                 }
             } else {
-                if (controller.onSpinner && controller.onGround && Mathf.Abs(body.velocity.x) < 0.3f && !controller.holding && controller.state != Enums.PowerupState.Giant) {
+                if (controller.onSpinner && controller.onGround && Mathf.Abs(body.velocity.x) < 0.3f && !controller.holding) {
                     targetEuler += new Vector3(0, -1800, 0) * Time.deltaTime;
                     instant = true;
                 } else if (controller.flying || controller.propeller) {

--- a/Assets/Scripts/Entity/Player/PlayerController.cs
+++ b/Assets/Scripts/Entity/Player/PlayerController.cs
@@ -1520,12 +1520,14 @@ public class PlayerController : MonoBehaviourPun, IPunObservable {
             flying &= bounce;
             propeller &= bounce;
 
-            if (onSpinner && state != Enums.PowerupState.Giant && !inShell && !holding && !(crouching && state == Enums.PowerupState.Shell)) {
+            if (onSpinner && !holding) {
                 photonView.RPC("PlaySound", RpcTarget.All, character.soundFolder + "/spinner_launch");
                 photonView.RPC("PlaySound", RpcTarget.All, "player/spinner_launch");
                 body.velocity = new Vector2(body.velocity.x, launchVelocity);
                 flying = true;
                 onGround = false;
+                crouching = false;
+                inShell = false;
                 return;
             }
 
@@ -1924,7 +1926,7 @@ public class PlayerController : MonoBehaviourPun, IPunObservable {
             if (drill)
                 photonView.RPC("SpawnParticle", RpcTarget.All, "Prefabs/Particle/GroundpoundDust", body.position);
 
-            if (onSpinner && Mathf.Abs(body.velocity.x) < 0.3f && !holding && state != Enums.PowerupState.Giant) {
+            if (onSpinner && Mathf.Abs(body.velocity.x) < 0.3f && !holding) {
                 Transform spnr = onSpinner.transform;
                 if (body.position.x > spnr.transform.position.x + 0.02f) {
                     body.position -= new Vector2(0.01f * 60f, 0) * Time.fixedDeltaTime;


### PR DESCRIPTION
I have adjusted the values for jumping based off of a side-by-side comparison of the original game and the remake, its probably not perfect, but overall it feels more or less the same.
I slightly increased the wall-jumping velocity, as it did not travel quite the same amount of distance as the original game.

Mega Mario can now fully use the spinner.
Shell Mario can now fully use the spinner, regardless of if he is in his shell or not.