### PR TITLE
ScrollCamera Camera Component Disables when Main Camera is Away From Edge of Level

### DIFF
--- a/Assets/Resources/Data/credits.txt
+++ b/Assets/Resources/Data/credits.txt
@@ -7,8 +7,9 @@ Amy54Desu
 AtwerJ
 AutumnLeafy
 CubbyCrazes
+DonKaiStorm
 GithubSPerez
-radedWarrior
+GradedWarrior
 Jeffjewett27
 kittenchilly
 Kraken

--- a/Assets/Resources/Prefabs/Static/GameManager.prefab
+++ b/Assets/Resources/Prefabs/Static/GameManager.prefab
@@ -416,6 +416,7 @@ GameObject:
   - component: {fileID: 482268095346116759}
   - component: {fileID: 482268095346116758}
   - component: {fileID: 8692065426933415886}
+  - component: {fileID: 7830399380807812602}
   m_Layer: 0
   m_Name: ScrollCamera
   m_TagString: Untagged
@@ -557,6 +558,19 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 46bee7e6d45c5f240826fa0a672ae652, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &7830399380807812602
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 482268095346116756}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 5c8924c95603bd7438ed9078e045c528, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  mainCameraTransform: {fileID: 0}
 --- !u!1 &482268096050949616
 GameObject:
   m_ObjectHideFlags: 0
@@ -3855,7 +3869,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 76.75
+  m_fontSize: 82.35
   m_fontSizeBase: 36
   m_fontWeight: 400
   m_enableAutoSizing: 1

--- a/Assets/Scenes/MainMenu.unity
+++ b/Assets/Scenes/MainMenu.unity
@@ -2005,7 +2005,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 41c5d135866d4444088fd55baaa2ae03, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  frame: 0.4801445
+  frame: 0.5137596
   fps: 8
   frames:
   - {fileID: 60390689, guid: f35c24c4a8384af48a1325892d1dc60f, type: 3}
@@ -13596,7 +13596,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 1820958463}
   m_HandleRect: {fileID: 1916143647}
   m_Direction: 2
-  m_Value: 1
+  m_Value: 0
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
@@ -19803,7 +19803,7 @@ MonoBehaviour:
   m_faceColor:
     serializedVersion: 2
     rgba: 4294967295
-  m_fontSize: 32.55
+  m_fontSize: 36.3
   m_fontSizeBase: 24
   m_fontWeight: 400
   m_enableAutoSizing: 1
@@ -55152,8 +55152,8 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 47220571}
   m_HandleRect: {fileID: 47220570}
   m_Direction: 2
-  m_Value: 0.9999998
-  m_Size: 0.6506274
+  m_Value: 1
+  m_Size: 0.7096356
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -56618,7 +56618,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 41c5d135866d4444088fd55baaa2ae03, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  frame: 0.4801426
+  frame: 1.5137596
   fps: 8
   frames:
   - {fileID: 1676685922, guid: bc84ac99b7339e644a9a148d5a22d9b3, type: 3}
@@ -56685,7 +56685,7 @@ SpriteRenderer:
   m_SortingLayerID: -1013106893
   m_SortingLayer: -1
   m_SortingOrder: 0
-  m_Sprite: {fileID: 1676685922, guid: bc84ac99b7339e644a9a148d5a22d9b3, type: 3}
+  m_Sprite: {fileID: -795459062, guid: bc84ac99b7339e644a9a148d5a22d9b3, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
@@ -57720,7 +57720,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 41c5d135866d4444088fd55baaa2ae03, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  frame: 0.4801426
+  frame: 1.5137596
   fps: 8
   frames:
   - {fileID: -1194393796, guid: 507f9d3e904abe34da025f747e616629, type: 3}
@@ -57787,7 +57787,7 @@ SpriteRenderer:
   m_SortingLayerID: -1013106893
   m_SortingLayer: -1
   m_SortingOrder: -2
-  m_Sprite: {fileID: -1194393796, guid: 507f9d3e904abe34da025f747e616629, type: 3}
+  m_Sprite: {fileID: -124428530, guid: 507f9d3e904abe34da025f747e616629, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0

--- a/Assets/Scripts/Camera/SecondaryCameraRenderController.cs
+++ b/Assets/Scripts/Camera/SecondaryCameraRenderController.cs
@@ -1,0 +1,44 @@
+using UnityEngine;
+
+public class SecondaryCameraRenderController : MonoBehaviour
+{
+    //Variable holding the Main Camera's Transfrom (the parent of the Scroll Camera)
+    public Transform mainCameraTransform;
+
+    //Stores the Max and Min values for X;
+    private float minX;
+    private float maxX;
+
+    //Stores the Instance of the Camera Component on the ScrollCamera
+    private Camera camera;
+
+    public void Start()
+    {
+        mainCameraTransform = gameObject.transform.parent.transform;
+        minX = GameManager.Instance.LevelMinX;
+        maxX = GameManager.Instance.LevelMaxX;
+        camera = GetComponent<Camera>();
+        //Invoke this method less than a frame per second (roughly 9 times per second)
+        InvokeRepeating("CameraRenderStatus", 0f, 0.11f);
+    }
+    public void CameraRenderStatus()
+    {
+        //If mainCameraTransform is between one unit behind MinX and 6 units in front of MinX OR between one unit in front of MaxX and 6 units behind MaxX, turn on Camera if not on.
+        //The 1 and 7 listed below are buffer zones listed to ensure that pop-in / pop-out doesn't appear.
+        if(mainCameraTransform.position.x > minX - 1 && mainCameraTransform.position.x < minX + 7 || mainCameraTransform.position.x < maxX + 1 && mainCameraTransform.position.x > maxX - 7)
+        {
+            if (!camera.isActiveAndEnabled)
+            {
+                //Turn on Camera
+                camera.enabled = true;
+            }
+            return;
+        }
+
+        //Otherwise, turn off the Camera if not off
+        if (camera.isActiveAndEnabled){
+            camera.enabled = false;
+        }
+    }
+    
+}

--- a/Assets/Scripts/Camera/SecondaryCameraRenderController.cs.meta
+++ b/Assets/Scripts/Camera/SecondaryCameraRenderController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 5c8924c95603bd7438ed9078e045c528
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Like with the closed pull request I made earlier, this disables the rendering of the ScrollCamera when away from the edge of a level. Unlike my old version, however, it uses the location of the base camera and the min/max X values of the level to determine whether to turn on/off.

Another difference is that rather than every frame, the method gets invoked every 0.11 seconds (which is 9 times per second), helping decrease the performance cost.

Other than changes related to that, I added my name to the Github Contributors credit list, and fixed GradedWarrior's credit in the .txt file too.