### PR TITLE
Disable LegacyAnimateSpriteRenderer when !IsVisible & VolumeWithDistance on Dead Enemies

### DIFF
--- a/Assets/Scripts/Entity/Enemy/KillableEntity.cs
+++ b/Assets/Scripts/Entity/Enemy/KillableEntity.cs
@@ -151,6 +151,10 @@ namespace NSMB.Entities {
                 return;
 
             } else if (IsDead || IsFrozen) {
+                //If the enemy is dead, disable the volume distance modifier so that dead enemies don't call that function...
+                if (IsDead) {
+                    GetComponent<VolumeWithDistance>().enabled = false;
+                }
                 gameObject.layer = Layers.LayerHitsNothing;
                 body.Freeze = false;
 
@@ -317,6 +321,9 @@ namespace NSMB.Entities {
             WasKilledByMega = false;
             WasCrushed = false;
             ComboCounter = 0;
+
+            //Re-enable the Volume with Distance when brought back to life
+            GetComponent<VolumeWithDistance>().enabled = true;
 
             if (body) {
                 body.Gravity = Vector2.down * 21.5f;

--- a/Assets/Scripts/Entity/World Elements/Coin.cs
+++ b/Assets/Scripts/Entity/World Elements/Coin.cs
@@ -64,6 +64,7 @@ namespace NSMB.Entities.Collectable {
         //CollectableEntity overrides
         public override void OnCollectedChanged() {
             sRenderer.enabled = !Collector;
+            GetComponent<VolumeWithDistance>().enabled = !Collector;
         }
     }
 }

--- a/Assets/Scripts/LegacyAnimateSpriteRenderer.cs
+++ b/Assets/Scripts/LegacyAnimateSpriteRenderer.cs
@@ -41,20 +41,22 @@ public class LegacyAnimateSpriteRenderer : MonoBehaviour {
 
     private void SetSprite() {
 
-        if (!isDisplaying || frames.Length == 0)
+        if (!isDisplaying)
             return;
 
         frame = Mathf.Repeat(frame, frames.Length);
-        int currentFrame = Mathf.FloorToInt(frame);
-        Sprite currentSprite = frames[currentFrame];
 
+        //If the Sprite Renderer is visible
+        if (sRenderer.isVisible) {
+            int currentFrame = Mathf.FloorToInt(frame);
+            Sprite currentSprite = frames[currentFrame];
+            if (sRenderer && currentSprite != sRenderer.sprite) {
+                sRenderer.sprite = currentSprite;
+            }
 
-        if (sRenderer && currentSprite != sRenderer.sprite) {
-            sRenderer.sprite = currentSprite;
-        }
-
-        if (image && currentSprite != image.sprite) {
-            image.sprite = currentSprite;
+            if (image && currentSprite != image.sprite) {
+                image.sprite = currentSprite;
+            }
         }
     }
 }


### PR DESCRIPTION
When objects that use LegacyAnimateSpriteRenderer are collected or killed (like coins for example), they still update the Sprite Renderer, despite not needing to. This makes it so that the updating of the Sprite Renderer is only done when on object is currently visible.
(NOTE: If you aren't seeing an improvement/difference in the Unity Editor, move the Scene View camera away from the level, as that also triggers the Object's isVisible tag.)

In addition, this commit also disables the VolumeWithDistance component for dead enemies and collected coins, since there would be no point in updating the volume of an object that can't be interacted with.