### PR TITLE
Different Enable/Disable Buttons for Character Toggle

### DIFF
--- a/Assets/Scenes/MainMenu.unity
+++ b/Assets/Scenes/MainMenu.unity
@@ -8458,6 +8458,7 @@ MonoBehaviour:
   - {fileID: 613028815, guid: 919785a51397c1a44816e9462ed989f9, type: 3}
   enabledCharacterButtonLogoColor: {r: 1, g: 1, b: 1, a: 1}
   disabledCharacterButtonLogoColor: {r: 0.5019608, g: 0.5019608, b: 0.5019608, a: 1}
+  paletteBackground: {fileID: 1472937426}
   paletteChooser: {fileID: 1885872616}
   teamChooser: {fileID: 501548763}
   spectateToggle: {fileID: 1370509651}
@@ -38608,7 +38609,7 @@ MonoBehaviour:
   m_HandleRect: {fileID: 791989380}
   m_Direction: 2
   m_Value: 0
-  m_Size: 1
+  m_Size: 0.8341102
   m_NumberOfSteps: 0
   m_OnValueChanged:
     m_PersistentCalls:
@@ -39172,7 +39173,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: 4, y: -3.9999847}
+  m_AnchoredPosition: {x: 4, y: -3.9999695}
   m_SizeDelta: {x: 86, y: 36}
   m_Pivot: {x: 1, y: 0}
 --- !u!1 &1155409046
@@ -47316,7 +47317,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: 613028815, guid: 919785a51397c1a44816e9462ed989f9, type: 3}
+  m_Sprite: {fileID: -335287802, guid: 919785a51397c1a44816e9462ed989f9, type: 3}
   m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -73361,7 +73362,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 0, y: -0.000015258789}
+  m_AnchoredPosition: {x: 0, y: -0.000030517578}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 0}
 --- !u!114 &1576260155

--- a/Assets/Scenes/MainMenu.unity
+++ b/Assets/Scenes/MainMenu.unity
@@ -692,7 +692,7 @@ MonoBehaviour:
   m_OnCullStateChanged:
     m_PersistentCalls:
       m_Calls: []
-  m_Sprite: {fileID: -655794942, guid: 919785a51397c1a44816e9462ed989f9, type: 3}
+  m_Sprite: {fileID: 1138117175, guid: 919785a51397c1a44816e9462ed989f9, type: 3}
   m_Type: 1
   m_PreserveAspect: 0
   m_FillCenter: 1
@@ -8450,10 +8450,12 @@ MonoBehaviour:
   characterButtonLogos:
   - {fileID: 820690679}
   - {fileID: 648328594}
-  enabledCharacterButtonSprite: {fileID: -655794942, guid: 919785a51397c1a44816e9462ed989f9,
-    type: 3}
-  disabledCharacterButtonSprite: {fileID: 613028815, guid: 919785a51397c1a44816e9462ed989f9,
-    type: 3}
+  enabledCharacterButtonSprites:
+  - {fileID: 1138117175, guid: 919785a51397c1a44816e9462ed989f9, type: 3}
+  - {fileID: -655794942, guid: 919785a51397c1a44816e9462ed989f9, type: 3}
+  disabledCharacterButtonSprites:
+  - {fileID: -335287802, guid: 919785a51397c1a44816e9462ed989f9, type: 3}
+  - {fileID: 613028815, guid: 919785a51397c1a44816e9462ed989f9, type: 3}
   enabledCharacterButtonLogoColor: {r: 1, g: 1, b: 1, a: 1}
   disabledCharacterButtonLogoColor: {r: 0.5019608, g: 0.5019608, b: 0.5019608, a: 1}
   paletteChooser: {fileID: 1885872616}
@@ -38605,7 +38607,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 791989381}
   m_HandleRect: {fileID: 791989380}
   m_Direction: 2
-  m_Value: 1
+  m_Value: 0
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
@@ -39170,7 +39172,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 1, y: 0}
   m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: 4, y: -3.9999924}
+  m_AnchoredPosition: {x: 4, y: -3.9999847}
   m_SizeDelta: {x: 86, y: 36}
   m_Pivot: {x: 1, y: 0}
 --- !u!1 &1155409046
@@ -72199,10 +72201,10 @@ MonoBehaviour:
   canvas: {fileID: 2030938839}
   handler: {fileID: 1295076279}
   nameText: {fileID: 277927507}
-  pingText: {fileID: 0}
   winsText: {fileID: 259235382}
   muteButtonText: {fileID: 836379551}
   colorStrip: {fileID: 223773483}
+  pingImage: {fileID: 0}
   background: {fileID: 702961852}
   dropdownBackgroundImage: {fileID: 16827555}
   blockerTemplate: {fileID: 842380516}
@@ -72430,7 +72432,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 0, y: -22.600006}
-  m_SizeDelta: {x: 383.57758, y: 0}
+  m_SizeDelta: {x: 383.74335, y: 0}
   m_Pivot: {x: 0, y: 0}
 --- !u!114 &1532295032
 MonoBehaviour:

--- a/Assets/Scripts/UI/MainMenu/New/InRoom/ProfilePanel.cs
+++ b/Assets/Scripts/UI/MainMenu/New/InRoom/ProfilePanel.cs
@@ -12,6 +12,7 @@ namespace NSMB.UI.MainMenu.Submenus {
         [SerializeField] private Image[] characterButtonImages, characterButtonLogos;
         [SerializeField] private Sprite[] enabledCharacterButtonSprites, disabledCharacterButtonSprites;
         [SerializeField] private Color enabledCharacterButtonLogoColor, disabledCharacterButtonLogoColor;
+        [SerializeField] private Image paletteBackground;
         [SerializeField] private PaletteChooser paletteChooser;
         [SerializeField] private TeamChooser teamChooser;
         [SerializeField] private SpriteChangingToggle spectateToggle;
@@ -83,6 +84,7 @@ namespace NSMB.UI.MainMenu.Submenus {
             }
 
             characterButtonImages[index].sprite = enabledCharacterButtonSprites[index];
+            paletteBackground.sprite = disabledCharacterButtonSprites[index];
             characterButtonImages[index].transform.SetAsLastSibling();
             if (index < characterButtonLogos.Length && characterButtonLogos[index]) {
                 characterButtonLogos[index].color = enabledCharacterButtonLogoColor;

--- a/Assets/Scripts/UI/MainMenu/New/InRoom/ProfilePanel.cs
+++ b/Assets/Scripts/UI/MainMenu/New/InRoom/ProfilePanel.cs
@@ -10,7 +10,7 @@ namespace NSMB.UI.MainMenu.Submenus {
 
         //---Serialized Variables
         [SerializeField] private Image[] characterButtonImages, characterButtonLogos;
-        [SerializeField] private Sprite enabledCharacterButtonSprite, disabledCharacterButtonSprite;
+        [SerializeField] private Sprite[] enabledCharacterButtonSprites, disabledCharacterButtonSprites;
         [SerializeField] private Color enabledCharacterButtonLogoColor, disabledCharacterButtonLogoColor;
         [SerializeField] private PaletteChooser paletteChooser;
         [SerializeField] private TeamChooser teamChooser;
@@ -74,7 +74,7 @@ namespace NSMB.UI.MainMenu.Submenus {
 
             for (int i = 0; i < characterButtonImages.Length; i++) {
                 var image = characterButtonImages[i];
-                image.sprite = disabledCharacterButtonSprite;
+                image.sprite = disabledCharacterButtonSprites[i];
                 image.transform.SetAsLastSibling();
 
                 if (i < characterButtonLogos.Length && characterButtonLogos[i]) {
@@ -82,7 +82,7 @@ namespace NSMB.UI.MainMenu.Submenus {
                 }
             }
 
-            characterButtonImages[index].sprite = enabledCharacterButtonSprite;
+            characterButtonImages[index].sprite = enabledCharacterButtonSprites[index];
             characterButtonImages[index].transform.SetAsLastSibling();
             if (index < characterButtonLogos.Length && characterButtonLogos[index]) {
                 characterButtonLogos[index].color = enabledCharacterButtonLogoColor;


### PR DESCRIPTION
This request adds different colors to the Mario and Luigi Character Toggle buttons, to help visually distinguish the two brothers (while also referencing the UI color differentiation usually seen in the Mario & Luigi games).

![Character_Toggle](https://github.com/user-attachments/assets/a9adcf2f-19cf-4562-af89-ae6ea763fad0)

This also adds the disabled variant of whatever brother you have selected to the palette selection backing menu, to add further visual distinction.