### PR TITLE
Destroy the Overall & Shirt GameObjects on the "Default Colors" Palette Option

### DIFF
--- a/Assets/Scripts/UI/MainMenu/PaletteButton.cs
+++ b/Assets/Scripts/UI/MainMenu/PaletteButton.cs
@@ -14,8 +14,11 @@ public class PaletteButton : MonoBehaviour, ISelectHandler {
 
     public void Instantiate(CharacterAsset player) {
         if (palette == null) {
-            shirt.enabled = false;
-            overalls.enabled = false;
+            if (shirt && overalls)
+            {
+                Destroy(shirt.gameObject);
+                Destroy(overalls.gameObject);
+            }
             return;
         }
 


### PR DESCRIPTION
Destroy the Overall & Shirt GameObjects on the "Default Colors" Palette Option instead of disabling them. As they aren't shown to the player (instead showing an 'X') and don't impact any functionality of the palette menu, why have them there?