### PR TITLE
Allocated Variable Changes to PhysicsObjectSystem & MarioPlayerSystem

### DIFF
--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayerSystem.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayerSystem.cs
@@ -98,13 +98,13 @@ namespace Quantum {
 
         public void HandleWalkingRunning(Frame f, ref Filter filter, MarioPlayerPhysicsInfo physics) {
             using var profilerScope = HostProfiler.Start("MarioPlayerSystem.HandleWalkingRunning");
-            ref var inputs = ref filter.Inputs;
             var mario = filter.MarioPlayer;
-            var physicsObject = filter.PhysicsObject;
 
             if (!QuantumUtils.Decrement(ref mario->WalljumpFrames)) {
                 return;
             }
+
+            var physicsObject = filter.PhysicsObject;
 
             if (mario->GroundpoundStandFrames > 0) {
                 if (!physicsObject->IsTouchingGround) {
@@ -125,6 +125,7 @@ namespace Quantum {
                 mario->IsSkidding = false;
             }
 
+            ref var inputs = ref filter.Inputs;
             bool run = (inputs.Sprint.IsDown || mario->CurrentPowerupState == PowerupState.MegaMushroom || mario->IsPropellerFlying) && !mario->IsSpinnerFlying;
             int maxStage;
             if (swimming) {
@@ -483,7 +484,6 @@ namespace Quantum {
 
         public void HandleGravity(Frame f, ref Filter filter, MarioPlayerPhysicsInfo physics) {
             using var profilerScope = HostProfiler.Start("MarioPlayerSystem.HandleGravity");
-            ref var inputs = ref filter.Inputs;
             var mario = filter.MarioPlayer;
             var physicsObject = filter.PhysicsObject;
 
@@ -507,8 +507,11 @@ namespace Quantum {
                 bool mega = mario->CurrentPowerupState == PowerupState.MegaMushroom;
                 bool mini = mario->CurrentPowerupState == PowerupState.MiniMushroom;
 
+
                 FP[] accArr = swimming ? physics.GravitySwimmingAcceleration : (mega ? physics.GravityMegaAcceleration : (mini ? physics.GravityMiniAcceleration : physics.GravityAcceleration));
                 FP acc = accArr[stage];
+
+                ref var inputs = ref filter.Inputs;
                 if (stage == 0 && !(inputs.Jump.IsDown || swimming || (!swimming && mario->SwimForceJumpTimer > 0))) {
                     acc = accArr[^1];
                 }
@@ -526,7 +529,6 @@ namespace Quantum {
             var mario = filter.MarioPlayer;
             var physicsObject = filter.PhysicsObject;
 
-            FP maxWalkSpeed = physics.WalkMaxVelocity[physics.WalkSpeedStage];
             FP terminalVelocity;
 
             if (mario->IsDead) {
@@ -551,6 +553,9 @@ namespace Quantum {
             } else if (mario->IsSpinnerFlying) {
                 terminalVelocity = mario->IsDrilling ? physics.TerminalVelocityDrilling : physics.TerminalVelocityFlying;
             } else if (mario->IsPropellerFlying) {
+
+                FP maxWalkSpeed = physics.WalkMaxVelocity[physics.WalkSpeedStage];
+
                 if (mario->IsDrilling) {
                     terminalVelocity = physics.TerminalVelocityDrilling;
                     physicsObject->Velocity.X = FPMath.Clamp(physicsObject->Velocity.X, -maxWalkSpeed * FP._0_25, maxWalkSpeed * FP._0_25);
@@ -581,13 +586,14 @@ namespace Quantum {
         public void HandleWallslide(Frame f, ref Filter filter, MarioPlayerPhysicsInfo physics) {
             using var profilerScope = HostProfiler.Start("MarioPlayerSystem.HandleWallslide");
             var mario = filter.MarioPlayer;
-            ref var inputs = ref filter.Inputs;
             var physicsObject = filter.PhysicsObject;
 
             if (mario->IsInShell || mario->IsGroundpounding || mario->IsCrouching || mario->IsDrilling 
                 || mario->IsSpinnerFlying || mario->IsInKnockback || physicsObject->IsUnderwater) {
                 return;
             }
+
+            ref var inputs = ref filter.Inputs;
 
             FPVector2 currentWallDirection;
             if (mario->WallslideLeft) {
@@ -679,7 +685,6 @@ namespace Quantum {
         private static readonly FPVector2 WallslideLowerHeightOffset = new(0, FP._0_20);
         private void HandleWallslideStopChecks(ref Filter filter, FPVector2 wallDirection) {
             using var profilerScope = HostProfiler.Start("MarioPlayerSystem.HandleWallslideStopChecks");
-            ref var inputs = ref filter.Inputs;
             var mario = filter.MarioPlayer;
             var physicsObject = filter.PhysicsObject;
 
@@ -692,6 +697,8 @@ namespace Quantum {
                 mario->WallslideEndFrames = 0;
                 return;
             }
+
+            ref var inputs = ref filter.Inputs;
 
             if ((wallDirection == FPVector2.Left && (!inputs.Left.IsDown || !physicsObject->IsTouchingLeftWall)) || (wallDirection == FPVector2.Right && (!inputs.Right.IsDown || !physicsObject->IsTouchingRightWall))) {
                 if (mario->WallslideEndFrames == 0) {
@@ -706,7 +713,6 @@ namespace Quantum {
 
         public void HandleFacingDirection(Frame f, ref Filter filter, MarioPlayerPhysicsInfo physics) {
             using var profilerScope = HostProfiler.Start("MarioPlayerSystem.HandleFacingDirection");
-            ref var inputs = ref filter.Inputs;
             var mario = filter.MarioPlayer;
             var physicsObject = filter.PhysicsObject;
 
@@ -716,6 +722,7 @@ namespace Quantum {
                 return;
             }
 
+            ref var inputs = ref filter.Inputs;
             bool rightOrLeft = (inputs.Right.IsDown ^ inputs.Left.IsDown);
 
             if (mario->WalljumpFrames > 0) {


### PR DESCRIPTION
There's several changes to the MarioPlayerSystem & PhysicsObjectSystem, but the main types of ones are below:

Caching/allocating variables closer to where they are used and past where a return would cause them to never be used (which makes the caching pointless in the latter case)

Removing Unused Arguments from methods that never get used



This results on my PC of a 10.94% reduction in Mean CPU simulation time and a 41.92% reduction in standard deviation.

The debug tests below were taken on Jungle. I loaded the scene directly, started the recording after the *POP* sound that instantiates the player [as the significantly lower CPU usage during the empty time and the sudden SPIKE when loading the player influence the recording results], and sat idle for about 5100 frames. Prior measurement attempts ran into 15000 frames, but didn't start at the *POP* but instead when the scene loaded, affecting the results.

Before (Mean: 0.3272ms || stddev: 0.0551ms)
![BeforeCommit](https://github.com/user-attachments/assets/4ef4b7f0-ed19-4bdf-a9a6-5045ba333271)

After (Mean: 0.2914ms || stddev: 0.0320ms):
![AfterCommit](https://github.com/user-attachments/assets/6217576b-d0d5-41eb-8edf-8fb75edbca51)

Difference: 0.0358ms on the mean and 0.0231ms on the stddev. This is where the 10.94% reduction and 41.92% reduction come from respectively

Reasoning: I can assume that caching the variables closer to where they are used results not only in better cache hit results on the CPU, but also skips the cases where the variable is allocated but never used due to a return case leaving the method.

I'm not certain if this increase will be seen on all computers (as my numbers before the change were different than what iPod's on base nightly), but I noticed the 40+% reduction in the deviation and figured that alone was worth making a request to investigate further.
