### PR TITLE
WebGL Infinite Load when switching Regions / Reconnecting Issue fixed

### DIFF
--- a/Assets/Photon/PhotonRealtime/Code/RealtimeClient.cs
+++ b/Assets/Photon/PhotonRealtime/Code/RealtimeClient.cs
@@ -714,11 +714,8 @@ namespace Photon.Realtime
         private void CheckConnectSetupWebGl()
         {
             #if UNITY_WEBGL
-            if (this.RealtimePeer.TransportProtocol != ConnectionProtocol.WebSocket && this.RealtimePeer.TransportProtocol != ConnectionProtocol.WebSocketSecure)
-            {
                 Log.Warn("WebGL requires WebSockets. Switching TransportProtocol to WebSocketSecure.", this.LogLevel, this.LogPrefix);
                 this.AppSettings.Protocol = ConnectionProtocol.WebSocketSecure;
-            }
 
             this.AppSettings.EnableProtocolFallback = false; // no fallback on WebGL
             #endif


### PR DESCRIPTION
The first time when connecting to a region (when booting up in this context and probably most times) everything works just fine but Reconnecting or anything that makes the "Connecting..." Screen appear after the first time appearing will softlock the game and infinite load, a simple script change is needed for this to be fixed and nothing (should) break from this, THIS IS A WEBGL ONLY PROBLEM

The Video below showcases this before and after the change

https://github.com/user-attachments/assets/5f4b030d-cfd1-4457-a635-1e8f945c26f8

