### PR TITLE
Fix spectator switching during replay when using D-Pad or analog stick

### DIFF
--- a/Assets/Scripts/UI/Game/PlayerElements.cs
+++ b/Assets/Scripts/UI/Game/PlayerElements.cs
@@ -232,7 +232,7 @@ namespace NSMB.UI.Game {
         }
 
         private unsafe void OnNavigate(InputAction.CallbackContext context) {
-            if (!spectating || cameraAnimator.Mode != CameraAnimator.CameraMode.FollowPlayer || pauseMenu.IsPaused || Game.Frames.Predicted.Global->GameState >= GameState.Ended) {
+            if (!spectating || cameraAnimator.Mode != CameraAnimator.CameraMode.FollowPlayer || pauseMenu.IsPaused || Game.Frames.Predicted.Global->GameState >= GameState.Ended || Game.Session.IsReplay) {
                 previousNavigate = Vector2.zero;
                 return;
             }


### PR DESCRIPTION
## Summary
Previously, during replay mode, pressing the D-Pad or moving the analog stick would unintentionally switch the currently spectated player.  
This behavior was inconsistent with the intended control scheme.

## Fix
Now, the spectator player can only be switched explicitly via the following bindings:
- `controls.ui.next`
- `controls.ui.previous`

All other key or gamepad inputs no longer affect spectator switching.