### PR TITLE
Minimap Star Arrows Tweak

### DIFF
--- a/Assets/Scripts/UI/Game/Track/TrackIcon.cs
+++ b/Assets/Scripts/UI/Game/Track/TrackIcon.cs
@@ -49,22 +49,8 @@ namespace NSMB.UI.Game.Track {
             transform.localPosition = new(percentage * trackWidth - trackMaxX, transform.localPosition.y, transform.localPosition.z);
 
             if (upArrow && downArrow) {
-                float cameraBottom = stage.CameraMinPosition.Y.AsFloat;
-                float cameraTop = Mathf.Max(stage.CameraMinPosition.Y.AsFloat + 7, stage.CameraMaxPosition.Y.AsFloat);
-                float stageHeight = cameraTop - cameraBottom;
-                if (stageHeight > 18) {
-                    // Thirds
-                    upArrow.enabled = targetTransform.position.y > cameraBottom - (stageHeight / 3f);
-                    downArrow.enabled = targetTransform.position.y < cameraTop + (stageHeight / 3f);
-                } else if (stageHeight > 12) {
-                    // Halves
-                    upArrow.enabled = targetTransform.position.y > cameraBottom + (stageHeight / 2f);
-                    downArrow.enabled = !upArrow.enabled;
-                } else {
-                    // Screen bounds
-                    upArrow.enabled = targetTransform.position.y > cameraTop;
-                    downArrow.enabled = targetTransform.position.y < cameraBottom;
-                }
+                upArrow.enabled = Camera.main.transform.position.y +3.25 < targetTransform.position.y;
+                downArrow.enabled = Camera.main.transform.position.y -3.25 > targetTransform.position.y;
             }
         }
     }


### PR DESCRIPTION
The changes only Effect pipes, ice, sky, volcano, and beach, just as it should
if a star is roughly a little less than half outside of vertical camera view, it will display one of the arrows