### PR TITLE
Hide Replay UI on mouse idle, like on YouTube's video player.

### DIFF
--- a/Assets/Resources/Prefabs/Static/PlayerElements.prefab
+++ b/Assets/Resources/Prefabs/Static/PlayerElements.prefab
@@ -13554,6 +13554,7 @@ RectTransform:
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_ConstrainProportionsScale: 0
   m_Children:
+  - {fileID: 975854882793768241}
   - {fileID: 7207626703234073965}
   - {fileID: 1310746913248571851}
   - {fileID: 2059523408431071351}
@@ -14978,6 +14979,95 @@ MonoBehaviour:
   deselectedColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
   translationKey: 
   twoSided: 1
+--- !u!1 &6384058270967109945
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 975854882793768241}
+  - component: {fileID: 7249758486017390357}
+  - component: {fileID: 8707271919688239819}
+  - component: {fileID: 134371305933940428}
+  m_Layer: 2
+  m_Name: HideOnIdleArea
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &975854882793768241
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6384058270967109945}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1981666707050521408}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7249758486017390357
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6384058270967109945}
+  m_CullTransparentMesh: 1
+--- !u!114 &8707271919688239819
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6384058270967109945}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 0}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 0}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &134371305933940428
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6384058270967109945}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a4df755f69cfd324693d2dc6c7e7ebd9, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  targetObject: {fileID: 1464872262009445458}
 --- !u!1 &6394529396616111786
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Camera/CameraAnimator.cs
+++ b/Assets/Scripts/Camera/CameraAnimator.cs
@@ -9,6 +9,7 @@ using UnityEngine;
 using UnityEngine.EventSystems;
 using UnityEngine.InputSystem;
 using UnityEngine.UI;
+using LayerMask = UnityEngine.LayerMask;
 
 namespace NSMB.Cameras {
     public unsafe class CameraAnimator : ResizingCamera {
@@ -189,7 +190,9 @@ namespace NSMB.Cameras {
                     playerElements.Canvas.GetComponent<GraphicRaycaster>().Raycast(new PointerEventData(EventSystem.current) {
                         position = pointerScreen
                     }, results);
-                    freecamMouseDragging = (results.Count == 0);
+                    freecamMouseDragging = (results.Count == 0) || (results.Count == 1 &&
+                                                                    results[0].gameObject.layer ==
+                                                                    LayerMask.NameToLayer("Ignore Raycast"));
                     clickHeld = true;
                 }
             } else {

--- a/Assets/Scripts/UI/Elements/HideOnIdle.cs
+++ b/Assets/Scripts/UI/Elements/HideOnIdle.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+using UnityEngine.EventSystems;
+
+public class HideOnIdle : MonoBehaviour, IPointerMoveHandler, IPointerUpHandler
+{
+    //---Serialized Variables
+    [SerializeField] private GameObject targetObject;
+    
+    //---Private Variables
+    private bool isShowing = true;
+    private bool isOverObject = false;
+    private Coroutine hideCoroutine;
+    private CanvasGroup targetCanvasGroup;
+
+    private void Awake() {
+        targetObject.TryGetComponent(out targetCanvasGroup);
+        hideCoroutine = StartCoroutine(HideAfterDelay());
+    }
+    
+    public void OnPointerMove(PointerEventData eventData) {
+        if (!targetObject) return;
+        
+        var raycastResults = new List<RaycastResult>();
+        EventSystem.current.RaycastAll(eventData, raycastResults);
+        isOverObject = raycastResults.Any(result =>
+            result.gameObject == targetObject || result.gameObject.transform.IsChildOf(targetObject.transform));
+
+        SetVisibility(true);
+        if (hideCoroutine != null) {
+            StopCoroutine(hideCoroutine);
+            hideCoroutine = null;
+        }
+        if(!isOverObject) hideCoroutine = StartCoroutine(HideAfterDelay());
+    }
+
+    public void OnPointerUp(PointerEventData eventData) {
+        OnPointerMove(eventData);
+    }
+    
+    private IEnumerator HideAfterDelay() {
+        yield return new WaitForSeconds(2f);
+        SetVisibility(false);
+    }
+
+    private void SetVisibility(bool how) {
+        if (targetCanvasGroup) {
+            targetCanvasGroup.alpha = how ? 1 : 0;
+            targetCanvasGroup.interactable = how;
+        }
+        else targetObject.SetActive(how);
+        isShowing = how;
+    }
+}

--- a/Assets/Scripts/UI/Elements/HideOnIdle.cs.meta
+++ b/Assets/Scripts/UI/Elements/HideOnIdle.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: a4df755f69cfd324693d2dc6c7e7ebd9


### PR DESCRIPTION
the replay ui is quite a lot in the way of the action, and the "hide replay controls" option in the pause menu is quite far away.

this pull request makes it so the replay controls only show while the mouse is moving, or the cursor is over them. if moved away and kept idle, they disappear after a small delay. this behaviour is very similar to some web video players out there.