### PR TITLE
Fix nonlinear zoom speed (freecam)

### DIFF
--- a/Assets/Resources/Prefabs/Static/PlayerElements.prefab
+++ b/Assets/Resources/Prefabs/Static/PlayerElements.prefab
@@ -14345,7 +14345,7 @@ MonoBehaviour:
   playerElements: {fileID: 2058053739306675502}
   secondaryPositioners:
   - {fileID: 5933699861429858116}
-  zoomSpeed: 2
+  zoomSpeed: 0.5
   moveSpeed: 2
   zoomSfx: {fileID: 8859060311520427125}
 --- !u!114 &3464307077645618015

--- a/Assets/Scripts/Camera/CameraAnimator.cs
+++ b/Assets/Scripts/Camera/CameraAnimator.cs
@@ -24,7 +24,7 @@ namespace NSMB.Cameras {
         //---Serialized Variables
         [SerializeField] private PlayerElements playerElements;
         [SerializeField] private List<SecondaryCameraPositioner> secondaryPositioners;
-        [SerializeField] private float zoomSpeed = 3, moveSpeed = 2;
+        [SerializeField] private float zoomSpeed = 1, moveSpeed = 2;
         [SerializeField] private AudioSource zoomSfx;
 
         //---Private Variables
@@ -225,7 +225,7 @@ namespace NSMB.Cameras {
 
             float maxOrthoSize = stage.TileDimensions.X * 0.25f / ourCamera.aspect;
             if (zoomAmount != 0) {
-                float newOrthoSize = ourCamera.orthographicSize + (zoomAmount * zoomSpeed * Time.unscaledDeltaTime);
+                float newOrthoSize = ourCamera.orthographicSize + (zoomAmount * zoomSpeed * Time.unscaledDeltaTime * ourCamera.orthographicSize);
                 newOrthoSize = Mathf.Clamp(newOrthoSize, 0.5f, maxOrthoSize);
                 ourCamera.orthographicSize = newOrthoSize;
 


### PR DESCRIPTION
The current zoom input is too coarse when zoomed in and unusably slow when zoomed out. Setting a new zoom value should be relative to the current zoom value for it to feel "linear" to us. This PR applies this, making the speed consistent and less "tedious".

[Demo video](https://discord.com/channels/956396409731551263/987953379005308968/1447113347979018340) (on the server).