### PR TITLE
PowerUP Changes (Probability Formula, System)

### DIFF
--- a/Assets/QuantumUser/AssetObjects/Gamemodes/CoinRunnersGamemode.asset
+++ b/Assets/QuantumUser/AssetObjects/Gamemodes/CoinRunnersGamemode.asset
@@ -23,7 +23,7 @@ MonoBehaviour:
   ObjectiveSymbolPrefix: c
   AllCoinItems:
   - Id:
-      Value: 271390802845879304
+      Value: 481353246829238635
   - Id:
       Value: 390055422968795145
   - Id:
@@ -37,7 +37,7 @@ MonoBehaviour:
   - Id:
       Value: 402398838204577684
   - Id:
-      Value: 269903407669338010
+      Value: 315844579913471239
   - Id:
       Value: 378514462062875007
   - Id:

--- a/Assets/QuantumUser/AssetObjects/Gamemodes/StarChasersGamemode.asset
+++ b/Assets/QuantumUser/AssetObjects/Gamemodes/StarChasersGamemode.asset
@@ -23,7 +23,7 @@ MonoBehaviour:
   ObjectiveSymbolPrefix: S
   AllCoinItems:
   - Id:
-      Value: 271390802845879304
+      Value: 481353246829238635
   - Id:
       Value: 390055422968795145
   - Id:
@@ -37,7 +37,7 @@ MonoBehaviour:
   - Id:
       Value: 402398838204577684
   - Id:
-      Value: 269903407669338010
+      Value: 315844579913471239
   - Id:
       Value: 378514462062875007
   FallbackCoinItem:

--- a/Assets/QuantumUser/AssetObjects/Items/1-Up.asset
+++ b/Assets/QuantumUser/AssetObjects/Items/1-Up.asset
@@ -26,15 +26,15 @@ MonoBehaviour:
   BelowAverageBonus:
     RawValue: 0
   BlockSpawnSoundEffect: 69
-  Flags: 24
+  Flags: 56
   MaxNumberOfItems: 0
-  MaxMatchingPowerStates: 0
-  MaxMatchingReserveStates: 0
   CameraSpawnOffset:
     X:
       RawValue: 0
     Y:
       RawValue: 110100
+  MaxMatchingPowerStates: 0
+  MaxMatchingReserveState: 0
   State: 0
   SoundPlaysEverywhere: 0
   SoundEffect: 78

--- a/Assets/QuantumUser/AssetObjects/Items/1-Up.asset
+++ b/Assets/QuantumUser/AssetObjects/Items/1-Up.asset
@@ -18,7 +18,7 @@ MonoBehaviour:
       Value: 421291512996345105
   Prefab:
     Id:
-      Value: 0
+      Value: 1365421339623582075
   SpawnChance:
     RawValue: 0
   AboveAverageBonus:
@@ -27,7 +27,9 @@ MonoBehaviour:
     RawValue: 0
   BlockSpawnSoundEffect: 69
   Flags: 24
+  MaxNumberOfItems: 0
   MaxMatchingPowerStates: 0
+  MaxMatchingReserveStates: 0
   CameraSpawnOffset:
     X:
       RawValue: 0

--- a/Assets/QuantumUser/AssetObjects/Items/1-Up.asset
+++ b/Assets/QuantumUser/AssetObjects/Items/1-Up.asset
@@ -21,15 +21,13 @@ MonoBehaviour:
       Value: 0
   SpawnChance:
     RawValue: 0
-  LosingSpawnBonus:
+  AboveAverageBonus:
+    RawValue: 0
+  BelowAverageBonus:
     RawValue: 0
   BlockSpawnSoundEffect: 69
-  BigPowerup: 0
-  VerticalPowerup: 0
-  CustomPowerup: 1
-  LivesOnlyPowerup: 1
-  CanSpawnFromBlock: 1
-  OnlyOneCanExist: 0
+  Flags: 24
+  MaxMatchingPowerStates: 0
   CameraSpawnOffset:
     X:
       RawValue: 0

--- a/Assets/QuantumUser/AssetObjects/Items/BlueShell.asset
+++ b/Assets/QuantumUser/AssetObjects/Items/BlueShell.asset
@@ -20,12 +20,12 @@ MonoBehaviour:
     Id:
       Value: 1466930856010351358
   SpawnChance:
-    RawValue: 98304
-  LosingSpawnBonus:
-    RawValue: -16384
+    RawValue: 81920
+  AboveAverageBonus:
+    RawValue: 131072
+  BelowAverageBonus:
+    RawValue: -131072
   BlockSpawnSoundEffect: 69
-  BigPowerup: 0
-  VerticalPowerup: 0
   CustomPowerup: 0
   LivesOnlyPowerup: 0
   CanSpawnFromBlock: 1
@@ -76,5 +76,5 @@ MonoBehaviour:
     Keys: []
   StatePriority: 2
   ItemPriority: 2
-  EnterReserveIfOverridden: 1
+  EnterReserveIfOverridden: 0
   SfxOverrides: []

--- a/Assets/QuantumUser/AssetObjects/Items/BlueShell.asset
+++ b/Assets/QuantumUser/AssetObjects/Items/BlueShell.asset
@@ -26,13 +26,15 @@ MonoBehaviour:
   BelowAverageBonus:
     RawValue: -131072
   BlockSpawnSoundEffect: 69
-  Flags: 0
-  MaxMatchingPowerStates: 0
+  Flags: 48
+  MaxNumberOfItems: 0
   CameraSpawnOffset:
     X:
       RawValue: 0
     Y:
       RawValue: 110100
+  MaxMatchingPowerStates: 0
+  MaxMatchingReserveState: 0
   State: 6
   SoundPlaysEverywhere: 0
   SoundEffect: 16

--- a/Assets/QuantumUser/AssetObjects/Items/BlueShell.asset
+++ b/Assets/QuantumUser/AssetObjects/Items/BlueShell.asset
@@ -26,10 +26,8 @@ MonoBehaviour:
   BelowAverageBonus:
     RawValue: -131072
   BlockSpawnSoundEffect: 69
-  CustomPowerup: 0
-  LivesOnlyPowerup: 0
-  CanSpawnFromBlock: 1
-  OnlyOneCanExist: 0
+  Flags: 0
+  MaxMatchingPowerStates: 0
   CameraSpawnOffset:
     X:
       RawValue: 0

--- a/Assets/QuantumUser/AssetObjects/Items/FireFlower.asset
+++ b/Assets/QuantumUser/AssetObjects/Items/FireFlower.asset
@@ -20,16 +20,15 @@ MonoBehaviour:
     Id:
       Value: 1349070666859566638
   SpawnChance:
-    RawValue: 131072
-  LosingSpawnBonus:
-    RawValue: 49152
+    RawValue: 98304
+  AboveAverageBonus:
+    RawValue: -98304
+  BelowAverageBonus:
+    RawValue: 16384
   BlockSpawnSoundEffect: 69
-  BigPowerup: 0
-  VerticalPowerup: 0
-  CustomPowerup: 0
-  LivesOnlyPowerup: 0
-  CanSpawnFromBlock: 1
-  OnlyOneCanExist: 0
+  Flags: 0
+  MaxNumberOfItems: 0
+  MaxMatchingPowerStates: 0
   CameraSpawnOffset:
     X:
       RawValue: 0

--- a/Assets/QuantumUser/AssetObjects/Items/FireFlower.asset
+++ b/Assets/QuantumUser/AssetObjects/Items/FireFlower.asset
@@ -26,14 +26,15 @@ MonoBehaviour:
   BelowAverageBonus:
     RawValue: 16384
   BlockSpawnSoundEffect: 69
-  Flags: 0
+  Flags: 48
   MaxNumberOfItems: 0
-  MaxMatchingPowerStates: 0
   CameraSpawnOffset:
     X:
       RawValue: 0
     Y:
       RawValue: 110100
+  MaxMatchingPowerStates: 0
+  MaxMatchingReserveState: 0
   State: 3
   SoundPlaysEverywhere: 0
   SoundEffect: 16

--- a/Assets/QuantumUser/AssetObjects/Items/GoldBlock.asset
+++ b/Assets/QuantumUser/AssetObjects/Items/GoldBlock.asset
@@ -26,9 +26,8 @@ MonoBehaviour:
   BelowAverageBonus:
     RawValue: 262144
   BlockSpawnSoundEffect: 69
-  Flags: 4
-  MaxNumberOfItems: 0
-  MaxMatchingPowerStates: 0
+  Flags: 36
+  MaxNumberOfItems: 1
   CameraSpawnOffset:
     X:
       RawValue: 0

--- a/Assets/QuantumUser/AssetObjects/Items/GoldBlock.asset
+++ b/Assets/QuantumUser/AssetObjects/Items/GoldBlock.asset
@@ -21,15 +21,14 @@ MonoBehaviour:
       Value: 1302927369648075827
   SpawnChance:
     RawValue: -65536
-  LosingSpawnBonus:
+  AboveAverageBonus:
+    RawValue: 0
+  BelowAverageBonus:
     RawValue: 262144
   BlockSpawnSoundEffect: 69
-  BigPowerup: 0
-  VerticalPowerup: 0
-  CustomPowerup: 0
-  LivesOnlyPowerup: 0
-  CanSpawnFromBlock: 0
-  OnlyOneCanExist: 1
+  Flags: 4
+  MaxNumberOfItems: 0
+  MaxMatchingPowerStates: 0
   CameraSpawnOffset:
     X:
       RawValue: 0

--- a/Assets/QuantumUser/AssetObjects/Items/HammerSuit.asset
+++ b/Assets/QuantumUser/AssetObjects/Items/HammerSuit.asset
@@ -26,7 +26,7 @@ MonoBehaviour:
   BelowAverageBonus:
     RawValue: 131072
   BlockSpawnSoundEffect: 69
-  Flags: 4
+  Flags: 52
   MaxNumberOfItems: 0
   CameraSpawnOffset:
     X:

--- a/Assets/QuantumUser/AssetObjects/Items/HammerSuit.asset
+++ b/Assets/QuantumUser/AssetObjects/Items/HammerSuit.asset
@@ -20,16 +20,15 @@ MonoBehaviour:
     Id:
       Value: 1472665878288241371
   SpawnChance:
-    RawValue: 32768
-  LosingSpawnBonus:
     RawValue: 98304
+  AboveAverageBonus:
+    RawValue: -131072
+  BelowAverageBonus:
+    RawValue: 131072
   BlockSpawnSoundEffect: 69
-  BigPowerup: 0
-  VerticalPowerup: 0
-  CustomPowerup: 1
-  LivesOnlyPowerup: 0
-  CanSpawnFromBlock: 1
-  OnlyOneCanExist: 0
+  Flags: 4
+  MaxNumberOfItems: 0
+  MaxMatchingPowerStates: 1
   CameraSpawnOffset:
     X:
       RawValue: 0

--- a/Assets/QuantumUser/AssetObjects/Items/HammerSuit.asset
+++ b/Assets/QuantumUser/AssetObjects/Items/HammerSuit.asset
@@ -28,12 +28,13 @@ MonoBehaviour:
   BlockSpawnSoundEffect: 69
   Flags: 4
   MaxNumberOfItems: 0
-  MaxMatchingPowerStates: 1
   CameraSpawnOffset:
     X:
       RawValue: 0
     Y:
       RawValue: 110100
+  MaxMatchingPowerStates: 0
+  MaxMatchingReserveState: 0
   State: 7
   SoundPlaysEverywhere: 0
   SoundEffect: 16

--- a/Assets/QuantumUser/AssetObjects/Items/IceFlower.asset
+++ b/Assets/QuantumUser/AssetObjects/Items/IceFlower.asset
@@ -21,15 +21,14 @@ MonoBehaviour:
       Value: 1524544283524633813
   SpawnChance:
     RawValue: 32768
-  LosingSpawnBonus:
+  AboveAverageBonus:
+    RawValue: -8192
+  BelowAverageBonus:
     RawValue: 98304
   BlockSpawnSoundEffect: 69
-  BigPowerup: 0
-  VerticalPowerup: 0
-  CustomPowerup: 1
-  LivesOnlyPowerup: 0
-  CanSpawnFromBlock: 1
-  OnlyOneCanExist: 0
+  Flags: 4
+  MaxNumberOfItems: 0
+  MaxMatchingPowerStates: 0
   CameraSpawnOffset:
     X:
       RawValue: 0

--- a/Assets/QuantumUser/AssetObjects/Items/IceFlower.asset
+++ b/Assets/QuantumUser/AssetObjects/Items/IceFlower.asset
@@ -26,14 +26,15 @@ MonoBehaviour:
   BelowAverageBonus:
     RawValue: 98304
   BlockSpawnSoundEffect: 69
-  Flags: 4
+  Flags: 52
   MaxNumberOfItems: 0
-  MaxMatchingPowerStates: 0
   CameraSpawnOffset:
     X:
       RawValue: 0
     Y:
       RawValue: 110100
+  MaxMatchingPowerStates: 0
+  MaxMatchingReserveState: 0
   State: 4
   SoundPlaysEverywhere: 0
   SoundEffect: 16

--- a/Assets/QuantumUser/AssetObjects/Items/MegaMushroom.asset
+++ b/Assets/QuantumUser/AssetObjects/Items/MegaMushroom.asset
@@ -9,13 +9,13 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: a77651c98eb177748a49241e377f4457, type: 3}
+  m_Script: {fileID: 11500000, guid: 09abfd75f8de0ab47b15cc437e916a34, type: 3}
   m_Name: MegaMushroom
-  m_EditorClassIdentifier: 
+  m_EditorClassIdentifier: Quantum.Simulation::MegaMushroomPowerupAsset
   Identifier:
     Path: QuantumUser/AssetObjects/Items/MegaMushroom
     Guid:
-      Value: 269903407669338010
+      Value: 481353246829238635
   Prefab:
     Id:
       Value: 1300211052819551813
@@ -24,14 +24,11 @@ MonoBehaviour:
   AboveAverageBonus:
     RawValue: 0
   BelowAverageBonus:
-    RawValue: 0
+    RawValue: 196608
   BlockSpawnSoundEffect: 99
-  BigPowerup: 1
-  VerticalPowerup: 0
-  CustomPowerup: 0
-  LivesOnlyPowerup: 0
-  CanSpawnFromBlock: 1
-  OnlyOneCanExist: 0
+  Flags: 1
+  MaxNumberOfItems: 0
+  MaxMatchingPowerStates: 1
   CameraSpawnOffset:
     X:
       RawValue: 0
@@ -79,3 +76,5 @@ MonoBehaviour:
   ItemPriority: 4
   EnterReserveIfOverridden: 1
   SfxOverrides: []
+  GrowAnimationDuration:
+    RawValue: 98304

--- a/Assets/QuantumUser/AssetObjects/Items/MegaMushroom.asset
+++ b/Assets/QuantumUser/AssetObjects/Items/MegaMushroom.asset
@@ -21,8 +21,10 @@ MonoBehaviour:
       Value: 1300211052819551813
   SpawnChance:
     RawValue: -65536
-  LosingSpawnBonus:
-    RawValue: 196608
+  AboveAverageBonus:
+    RawValue: 0
+  BelowAverageBonus:
+    RawValue: 0
   BlockSpawnSoundEffect: 99
   BigPowerup: 1
   VerticalPowerup: 0

--- a/Assets/QuantumUser/AssetObjects/Items/MegaMushroom.asset.meta
+++ b/Assets/QuantumUser/AssetObjects/Items/MegaMushroom.asset.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 348238c0b7671f944aaa8b9d272994f5
+guid: 2f5b677c66fff0c409c7e88879d71249
 labels:
 - QuantumAsset
 NativeFormatImporter:

--- a/Assets/QuantumUser/AssetObjects/Items/MiniMushroom.asset
+++ b/Assets/QuantumUser/AssetObjects/Items/MiniMushroom.asset
@@ -26,13 +26,15 @@ MonoBehaviour:
   BelowAverageBonus:
     RawValue: -147456
   BlockSpawnSoundEffect: 69
-  Flags: 0
-  MaxMatchingPowerStates: 0
+  Flags: 304
+  MaxNumberOfItems: 0
   CameraSpawnOffset:
     X:
       RawValue: 0
     Y:
       RawValue: 110100
+  MaxMatchingPowerStates: 0
+  MaxMatchingReserveState: 0
   State: 1
   SoundPlaysEverywhere: 0
   SoundEffect: 45

--- a/Assets/QuantumUser/AssetObjects/Items/MiniMushroom.asset
+++ b/Assets/QuantumUser/AssetObjects/Items/MiniMushroom.asset
@@ -9,27 +9,25 @@ MonoBehaviour:
   m_GameObject: {fileID: 0}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 09abfd75f8de0ab47b15cc437e916a34, type: 3}
+  m_Script: {fileID: 11500000, guid: a77651c98eb177748a49241e377f4457, type: 3}
   m_Name: MiniMushroom
-  m_EditorClassIdentifier: 
+  m_EditorClassIdentifier: Quantum.Simulation::PowerupAsset
   Identifier:
     Path: QuantumUser/AssetObjects/Items/MiniMushroom
     Guid:
-      Value: 271390802845879304
+      Value: 315844579913471239
   Prefab:
     Id:
       Value: 1414434856952255942
   SpawnChance:
     RawValue: 131072
-  LosingSpawnBonus:
-    RawValue: -262144
+  AboveAverageBonus:
+    RawValue: 229376
+  BelowAverageBonus:
+    RawValue: -147456
   BlockSpawnSoundEffect: 69
-  BigPowerup: 0
-  VerticalPowerup: 0
-  CustomPowerup: 0
-  LivesOnlyPowerup: 0
-  CanSpawnFromBlock: 1
-  OnlyOneCanExist: 0
+  Flags: 0
+  MaxMatchingPowerStates: 0
   CameraSpawnOffset:
     X:
       RawValue: 0
@@ -77,5 +75,3 @@ MonoBehaviour:
   ItemPriority: 2
   EnterReserveIfOverridden: 1
   SfxOverrides: []
-  GrowAnimationDuration:
-    RawValue: 98304

--- a/Assets/QuantumUser/AssetObjects/Items/MiniMushroom.asset.meta
+++ b/Assets/QuantumUser/AssetObjects/Items/MiniMushroom.asset.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: a79a59f03b5eabb41aabf2f6476ce154
+guid: 0123bc025b20ea142bc060ea0b8b9859
 labels:
 - QuantumAsset
 NativeFormatImporter:

--- a/Assets/QuantumUser/AssetObjects/Items/Mushroom.asset
+++ b/Assets/QuantumUser/AssetObjects/Items/Mushroom.asset
@@ -26,10 +26,9 @@ MonoBehaviour:
   BelowAverageBonus:
     RawValue: -131072
   BlockSpawnSoundEffect: 69
-  CustomPowerup: 0
-  LivesOnlyPowerup: 0
-  CanSpawnFromBlock: 1
-  OnlyOneCanExist: 0
+  Flags: 0
+  MaxNumberOfItems: 0
+  MaxMatchingPowerStates: 0
   CameraSpawnOffset:
     X:
       RawValue: 0

--- a/Assets/QuantumUser/AssetObjects/Items/Mushroom.asset
+++ b/Assets/QuantumUser/AssetObjects/Items/Mushroom.asset
@@ -20,12 +20,12 @@ MonoBehaviour:
     Id:
       Value: 1268531089014898302
   SpawnChance:
-    RawValue: 524288
-  LosingSpawnBonus:
-    RawValue: -524288
+    RawValue: 81920
+  AboveAverageBonus:
+    RawValue: 131072
+  BelowAverageBonus:
+    RawValue: -131072
   BlockSpawnSoundEffect: 69
-  BigPowerup: 0
-  VerticalPowerup: 0
   CustomPowerup: 0
   LivesOnlyPowerup: 0
   CanSpawnFromBlock: 1

--- a/Assets/QuantumUser/AssetObjects/Items/Mushroom.asset
+++ b/Assets/QuantumUser/AssetObjects/Items/Mushroom.asset
@@ -26,14 +26,15 @@ MonoBehaviour:
   BelowAverageBonus:
     RawValue: -131072
   BlockSpawnSoundEffect: 69
-  Flags: 0
+  Flags: 48
   MaxNumberOfItems: 0
-  MaxMatchingPowerStates: 0
   CameraSpawnOffset:
     X:
       RawValue: 0
     Y:
       RawValue: 110100
+  MaxMatchingPowerStates: 0
+  MaxMatchingReserveState: 0
   State: 2
   SoundPlaysEverywhere: 0
   SoundEffect: 16

--- a/Assets/QuantumUser/AssetObjects/Items/PropellerMushroom.asset
+++ b/Assets/QuantumUser/AssetObjects/Items/PropellerMushroom.asset
@@ -20,9 +20,11 @@ MonoBehaviour:
     Id:
       Value: 1286010981056643553
   SpawnChance:
-    RawValue: 32768
-  LosingSpawnBonus:
+    RawValue: 65536
+  AboveAverageBonus:
     RawValue: 98304
+  BelowAverageBonus:
+    RawValue: 32768
   BlockSpawnSoundEffect: 69
   BigPowerup: 0
   VerticalPowerup: 1

--- a/Assets/QuantumUser/AssetObjects/Items/PropellerMushroom.asset
+++ b/Assets/QuantumUser/AssetObjects/Items/PropellerMushroom.asset
@@ -26,12 +26,8 @@ MonoBehaviour:
   BelowAverageBonus:
     RawValue: 32768
   BlockSpawnSoundEffect: 69
-  BigPowerup: 0
-  VerticalPowerup: 1
-  CustomPowerup: 1
-  LivesOnlyPowerup: 0
-  CanSpawnFromBlock: 1
-  OnlyOneCanExist: 0
+  Flags: 2
+  MaxMatchingPowerStates: 0
   CameraSpawnOffset:
     X:
       RawValue: 0

--- a/Assets/QuantumUser/AssetObjects/Items/PropellerMushroom.asset
+++ b/Assets/QuantumUser/AssetObjects/Items/PropellerMushroom.asset
@@ -26,13 +26,15 @@ MonoBehaviour:
   BelowAverageBonus:
     RawValue: 32768
   BlockSpawnSoundEffect: 69
-  Flags: 2
-  MaxMatchingPowerStates: 0
+  Flags: 50
+  MaxNumberOfItems: 0
   CameraSpawnOffset:
     X:
       RawValue: 0
     Y:
       RawValue: 110100
+  MaxMatchingPowerStates: 0
+  MaxMatchingReserveState: 0
   State: 5
   SoundPlaysEverywhere: 0
   SoundEffect: 16

--- a/Assets/QuantumUser/AssetObjects/Items/Starman.asset
+++ b/Assets/QuantumUser/AssetObjects/Items/Starman.asset
@@ -26,10 +26,8 @@ MonoBehaviour:
   BelowAverageBonus:
     RawValue: 229376
   BlockSpawnSoundEffect: 69
-  CustomPowerup: 0
-  LivesOnlyPowerup: 0
-  CanSpawnFromBlock: 1
-  OnlyOneCanExist: 0
+  Flags: 256
+  MaxMatchingPowerStates: 0
   CameraSpawnOffset:
     X:
       RawValue: 0

--- a/Assets/QuantumUser/AssetObjects/Items/Starman.asset
+++ b/Assets/QuantumUser/AssetObjects/Items/Starman.asset
@@ -26,13 +26,15 @@ MonoBehaviour:
   BelowAverageBonus:
     RawValue: 229376
   BlockSpawnSoundEffect: 69
-  Flags: 256
-  MaxMatchingPowerStates: 0
+  Flags: 48
+  MaxNumberOfItems: 0
   CameraSpawnOffset:
     X:
       RawValue: 0
     Y:
       RawValue: 110100
+  MaxMatchingPowerStates: 0
+  MaxMatchingReserveState: 0
   State: 0
   SoundPlaysEverywhere: 0
   SoundEffect: 16

--- a/Assets/QuantumUser/AssetObjects/Items/Starman.asset
+++ b/Assets/QuantumUser/AssetObjects/Items/Starman.asset
@@ -20,12 +20,12 @@ MonoBehaviour:
     Id:
       Value: 1502268950446962426
   SpawnChance:
-    RawValue: 6554
-  LosingSpawnBonus:
-    RawValue: 98304
+    RawValue: 49152
+  AboveAverageBonus:
+    RawValue: -229376
+  BelowAverageBonus:
+    RawValue: 229376
   BlockSpawnSoundEffect: 69
-  BigPowerup: 0
-  VerticalPowerup: 0
   CustomPowerup: 0
   LivesOnlyPowerup: 0
   CanSpawnFromBlock: 1

--- a/Assets/QuantumUser/AssetObjects/Maps/Beach/CustomBeachStageData.asset
+++ b/Assets/QuantumUser/AssetObjects/Maps/Beach/CustomBeachStageData.asset
@@ -67,8 +67,8 @@ MonoBehaviour:
     B: 153
     A: 255
   HidePlayersOnMinimap: 0
-  SpawnBigPowerups: 0
-  SpawnVerticalPowerups: 1
+  BannedPowerUPs:
+  - {fileID: 11400000, guid: 348238c0b7671f944aaa8b9d272994f5, type: 2}
   SfxOverrides: []
   MainMusic:
   - Id:

--- a/Assets/QuantumUser/AssetObjects/Maps/Beach/CustomBeachStageData.asset
+++ b/Assets/QuantumUser/AssetObjects/Maps/Beach/CustomBeachStageData.asset
@@ -68,7 +68,7 @@ MonoBehaviour:
     A: 255
   HidePlayersOnMinimap: 0
   BannedPowerUPs:
-  - {fileID: 11400000, guid: 348238c0b7671f944aaa8b9d272994f5, type: 2}
+  - {fileID: 11400000, guid: 2f5b677c66fff0c409c7e88879d71249, type: 2}
   SfxOverrides: []
   MainMusic:
   - Id:

--- a/Assets/QuantumUser/AssetObjects/Maps/Bonus/CustomBonusStageData.asset
+++ b/Assets/QuantumUser/AssetObjects/Maps/Bonus/CustomBonusStageData.asset
@@ -67,8 +67,8 @@ MonoBehaviour:
     B: 255
     A: 255
   HidePlayersOnMinimap: 0
-  SpawnBigPowerups: 1
-  SpawnVerticalPowerups: 1
+  BannedPowerUPs:
+  - {fileID: 11400000, guid: 2f5b677c66fff0c409c7e88879d71249, type: 2}
   SfxOverrides: []
   MainMusic:
   - Id:

--- a/Assets/QuantumUser/AssetObjects/Maps/Fortress/DefaultFortressStageData.asset
+++ b/Assets/QuantumUser/AssetObjects/Maps/Fortress/DefaultFortressStageData.asset
@@ -68,7 +68,7 @@ MonoBehaviour:
     A: 255
   HidePlayersOnMinimap: 0
   BannedPowerUPs:
-  - {fileID: 11400000, guid: 348238c0b7671f944aaa8b9d272994f5, type: 2}
+  - {fileID: 11400000, guid: 2f5b677c66fff0c409c7e88879d71249, type: 2}
   - {fileID: 11400000, guid: 66847e430712048408ec06255e8732aa, type: 2}
   SfxOverrides: []
   MainMusic:

--- a/Assets/QuantumUser/AssetObjects/Maps/Fortress/DefaultFortressStageData.asset
+++ b/Assets/QuantumUser/AssetObjects/Maps/Fortress/DefaultFortressStageData.asset
@@ -67,8 +67,9 @@ MonoBehaviour:
     B: 170
     A: 255
   HidePlayersOnMinimap: 0
-  SpawnBigPowerups: 0
-  SpawnVerticalPowerups: 0
+  BannedPowerUPs:
+  - {fileID: 11400000, guid: 348238c0b7671f944aaa8b9d272994f5, type: 2}
+  - {fileID: 11400000, guid: 66847e430712048408ec06255e8732aa, type: 2}
   SfxOverrides: []
   MainMusic:
   - Id:

--- a/Assets/QuantumUser/AssetObjects/Maps/Grass/DefaultGrassStage.asset
+++ b/Assets/QuantumUser/AssetObjects/Maps/Grass/DefaultGrassStage.asset
@@ -43,127 +43,260 @@ MonoBehaviour:
   StaticColliders3D: []
   MapEntities:
   - Components:
-    - rid: 4891817686134161408
-    - rid: 4891817686134161409
-    - rid: 4891817686134161410
-    - rid: 4891817686134161411
-    - rid: 4891817686134161412
-    - rid: 4891817686134161413
+    - rid: 1889659263039569920
+    - rid: 1889659263039569921
+    - rid: 1889659263039569922
+    - rid: 1889659263039569923
+    - rid: 1889659263039569924
+    - rid: 1889659263039569925
   - Components:
-    - rid: 8499690517292908544
-    - rid: 8499690517292908545
-    - rid: 8499690517292908546
-    - rid: 8499690517292908547
-    - rid: 8499690517292908548
-    - rid: 8499690517292908549
+    - rid: 6570762336053755904
+    - rid: 6570762336053755905
+    - rid: 6570762336053755906
+    - rid: 6570762336053755907
+    - rid: 6570762336053755908
+    - rid: 6570762336053755909
   - Components:
-    - rid: 5292839420364324864
-    - rid: 5292839420364324865
-    - rid: 5292839420364324866
-    - rid: 5292839420364324867
-    - rid: 5292839420364324868
-    - rid: 5292839420364324869
+    - rid: 3395932105807495168
+    - rid: 3395932105807495169
+    - rid: 3395932105807495170
+    - rid: 3395932105807495171
+    - rid: 3395932105807495172
+    - rid: 3395932105807495173
   - Components:
-    - rid: 8401615228999041024
-    - rid: 8401615228999041025
-    - rid: 8401615228999041026
-    - rid: 8401615228999041027
-    - rid: 8401615228999041028
-    - rid: 8401615228999041029
+    - rid: 4573175170545483776
+    - rid: 4573175170545483777
+    - rid: 4573175170545483778
+    - rid: 4573175170545483779
+    - rid: 4573175170545483780
+    - rid: 4573175170545483781
   - Components:
-    - rid: 5634812294941638656
-    - rid: 5634812294941638657
-    - rid: 5634812294941638658
-    - rid: 5634812294941638659
-    - rid: 5634812294941638660
-    - rid: 5634812294941638661
+    - rid: 2967068392109899776
+    - rid: 2967068392109899777
+    - rid: 2967068392109899778
+    - rid: 2967068392109899779
+    - rid: 2967068392109899780
+    - rid: 2967068392109899781
   - Components:
-    - rid: 265259499483299840
-    - rid: 265259499483299841
-    - rid: 265259499483299842
-    - rid: 265259499483299843
-    - rid: 265259499483299844
-    - rid: 265259499483299845
+    - rid: 4446608830146543616
+    - rid: 4446608830146543617
+    - rid: 4446608830146543618
+    - rid: 4446608830146543619
+    - rid: 4446608830146543620
+    - rid: 4446608830146543621
   - Components:
-    - rid: 1812743607870816256
-    - rid: 1812743607870816257
-    - rid: 1812743607870816258
-    - rid: 1812743607870816259
-    - rid: 1812743607870816260
-    - rid: 1812743607870816261
-    - rid: 1812743607870816262
-    - rid: 1812743607870816263
-    - rid: 1812743607870816264
-    - rid: 1812743607870816265
-    - rid: 1812743607870816266
-    - rid: 1812743607870816267
-    - rid: 1812743607870816268
+    - rid: 7515263985617207296
+    - rid: 7515263985617207297
+    - rid: 7515263985617207298
+    - rid: 7515263985617207299
+    - rid: 7515263985617207300
+    - rid: 7515263985617207301
+    - rid: 7515263985617207302
+    - rid: 7515263985617207303
+    - rid: 7515263985617207304
+    - rid: 7515263985617207305
+    - rid: 7515263985617207306
+    - rid: 7515263985617207307
+    - rid: 7515263985617207308
   - Components:
-    - rid: 8670111536095690752
-    - rid: 8670111536095690753
-    - rid: 8670111536095690754
-    - rid: 8670111536095690755
-    - rid: 8670111536095690756
-    - rid: 8670111536095690757
-    - rid: 8670111536095690758
-    - rid: 8670111536095690759
-    - rid: 8670111536095690760
-    - rid: 8670111536095690761
-    - rid: 8670111536095690762
+    - rid: 777974220477956096
+    - rid: 777974220477956097
+    - rid: 777974220477956098
+    - rid: 777974220477956099
+    - rid: 777974220477956100
+    - rid: 777974220477956101
+    - rid: 777974220477956102
+    - rid: 777974220477956103
+    - rid: 777974220477956104
+    - rid: 777974220477956105
+    - rid: 777974220477956106
   - Components:
-    - rid: 7792369256158461952
-    - rid: 7792369256158461953
-    - rid: 7792369256158461954
-    - rid: 7792369256158461955
-    - rid: 7792369256158461956
-    - rid: 7792369256158461957
-    - rid: 7792369256158461958
-    - rid: 7792369256158461959
-    - rid: 7792369256158461960
-    - rid: 7792369256158461961
-    - rid: 7792369256158461962
+    - rid: 1904270922169188352
+    - rid: 1904270922169188353
+    - rid: 1904270922169188354
+    - rid: 1904270922169188355
+    - rid: 1904270922169188356
+    - rid: 1904270922169188357
+    - rid: 1904270922169188358
+    - rid: 1904270922169188359
+    - rid: 1904270922169188360
+    - rid: 1904270922169188361
+    - rid: 1904270922169188362
   - Components:
-    - rid: 3383382073929629696
-    - rid: 3383382073929629697
-    - rid: 3383382073929629698
-    - rid: 3383382073929629699
-    - rid: 3383382073929629700
-    - rid: 3383382073929629701
-    - rid: 3383382073929629702
-    - rid: 3383382073929629703
-    - rid: 3383382073929629704
-    - rid: 3383382073929629705
-    - rid: 3383382073929629706
+    - rid: 5636341017683689472
+    - rid: 5636341017683689473
+    - rid: 5636341017683689474
+    - rid: 5636341017683689475
+    - rid: 5636341017683689476
+    - rid: 5636341017683689477
+    - rid: 5636341017683689478
+    - rid: 5636341017683689479
+    - rid: 5636341017683689480
+    - rid: 5636341017683689481
+    - rid: 5636341017683689482
   - Components:
-    - rid: 8091843171643817984
-    - rid: 8091843171643817985
-    - rid: 8091843171643817986
-    - rid: 8091843171643817987
+    - rid: 9081208219925217280
+    - rid: 9081208219925217281
+    - rid: 9081208219925217282
+    - rid: 9081208219925217283
   - Components:
-    - rid: 1218192423251869696
-    - rid: 1218192423251869697
-    - rid: 1218192423251869698
-    - rid: 1218192423251869699
+    - rid: 7960537994111221760
+    - rid: 7960537994111221761
+    - rid: 7960537994111221762
+    - rid: 7960537994111221763
   - Components:
-    - rid: 6976460943924396032
-    - rid: 6976460943924396033
-    - rid: 6976460943924396034
-    - rid: 6976460943924396035
+    - rid: 8862042412541804544
+    - rid: 8862042412541804545
+    - rid: 8862042412541804546
+    - rid: 8862042412541804547
   SerializedTriangleDataUncompressedSize: 8
   references:
     version: 2
     RefIds:
-    - rid: 265259499483299840
+    - rid: 777974220477956096
       type: {class: Transform2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
       data:
         Position:
           X:
-            RawValue: 49152
+            RawValue: 344064
           Y:
-            RawValue: 212992
+            RawValue: 294912
         Rotation:
           RawValue: 0
-    - rid: 265259499483299841
+    - rid: 777974220477956097
+      type: {class: PhysicsCollider2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
+      data:
+        ShapeConfig:
+          ShapeType: 4
+          PolygonCollider:
+            Id:
+              Value: 0
+          CircleRadius:
+            RawValue: 0
+          CapsuleSize:
+            X:
+              RawValue: 0
+            Y:
+              RawValue: 0
+          EdgeExtent:
+            RawValue: 0
+          BoxExtents:
+            X:
+              RawValue: 9830
+            Y:
+              RawValue: 13107
+          PositionOffset:
+            X:
+              RawValue: 0
+            Y:
+              RawValue: 13173
+          RotationOffset:
+            RawValue: 0
+          UserTag: 0
+          IsPersistent: 1
+          CompoundShapes: []
+        Layer: 9
+        IsTrigger: 0
+        PhysicsMaterial:
+          Id:
+            Value: 0
+    - rid: 777974220477956098
+      type: {class: PhysicsCallbacks2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
+      data:
+        CallbackFlags:
+          Value: 4095
+    - rid: 777974220477956099
+      type: {class: CullablePrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
+      data:
+        Offset:
+          X:
+            RawValue: 0
+          Y:
+            RawValue: 16384
+        BroadRadius:
+          RawValue: 32768
+    - rid: 777974220477956100
+      type: {class: EnemyPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
+      data:
+        Spawnpoint:
+          X:
+            RawValue: 344064
+          Y:
+            RawValue: 294912
+        IgnorePlayerWhenRespawning:
+          Value: 0
+        DisableRespawning:
+          Value: 0
+    - rid: 777974220477956101
+      type: {class: FreezablePrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
+      data:
+        IceBlockSize:
+          X:
+            RawValue: 42598
+          Y:
+            RawValue: 42598
+        AutoBreakFrames: 180
+        AutoBreakGrabAdditionalFrames: 0
+        AutoBreakWhileHeld:
+          Value: 0
+        Offset:
+          X:
+            RawValue: 0
+          Y:
+            RawValue: 0
+        IsCarryable:
+          Value: 1
+        IsFlying:
+          Value: 0
+    - rid: 777974220477956102
+      type: {class: GoombaPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
+      data:
+        Speed:
+          RawValue: 57344
+    - rid: 777974220477956103
+      type: {class: InteractablePrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
+      data:
+        ColliderDisabled:
+          Value: 0
+    - rid: 777974220477956104
+      type: {class: InteractionInitiatorPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
+      data:
+        _empty_prototype_dummy_field_: 0
+    - rid: 777974220477956105
+      type: {class: PhysicsObjectPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
+      data:
+        Gravity:
+          X:
+            RawValue: 0
+          Y:
+            RawValue: -1409024
+        TerminalVelocity:
+          RawValue: -524288
+        IsFrozen:
+          Value: 0
+        DisableCollision:
+          Value: 0
+        SlowInLiquids:
+          Value: 1
+        IsWaterSolid:
+          Value: 0
+        BreakMegaObjects:
+          Value: 0
+    - rid: 777974220477956106
+      type: {class: WrappingObjectPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
+      data:
+        _empty_prototype_dummy_field_: 0
+    - rid: 1889659263039569920
+      type: {class: Transform2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
+      data:
+        Position:
+          X:
+            RawValue: -507904
+          Y:
+            RawValue: 278528
+        Rotation:
+          RawValue: 0
+    - rid: 1889659263039569921
       type: {class: PhysicsCollider2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
       data:
         ShapeConfig:
@@ -200,19 +333,19 @@ MonoBehaviour:
         PhysicsMaterial:
           Id:
             Value: 0
-    - rid: 265259499483299842
+    - rid: 1889659263039569922
       type: {class: PhysicsCallbacks2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
       data:
         CallbackFlags:
           Value: 0
-    - rid: 265259499483299843
+    - rid: 1889659263039569923
       type: {class: CoinPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
       data:
         CoinType:
           Value: 1
         Lifetime: 0
         UncollectableFrames: 0
-    - rid: 265259499483299844
+    - rid: 1889659263039569924
       type: {class: CullablePrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
       data:
         Offset:
@@ -222,22 +355,22 @@ MonoBehaviour:
             RawValue: 0
         BroadRadius:
           RawValue: 26214
-    - rid: 265259499483299845
+    - rid: 1889659263039569925
       type: {class: InteractablePrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
       data:
         ColliderDisabled:
           Value: 0
-    - rid: 1218192423251869696
+    - rid: 1904270922169188352
       type: {class: Transform2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
       data:
         Position:
           X:
-            RawValue: -393216
+            RawValue: -344064
           Y:
             RawValue: 32768
         Rotation:
           RawValue: 0
-    - rid: 1218192423251869697
+    - rid: 1904270922169188353
       type: {class: PhysicsCollider2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
       data:
         ShapeConfig:
@@ -256,39 +389,614 @@ MonoBehaviour:
             RawValue: 0
           BoxExtents:
             X:
-              RawValue: 32768
+              RawValue: 9830
             Y:
-              RawValue: 49152
+              RawValue: 13107
           PositionOffset:
             X:
               RawValue: 0
             Y:
-              RawValue: 49152
+              RawValue: 13173
           RotationOffset:
             RawValue: 0
           UserTag: 0
           IsPersistent: 1
           CompoundShapes: []
-        Layer: 0
+        Layer: 9
         IsTrigger: 0
         PhysicsMaterial:
           Id:
             Value: 0
-    - rid: 1218192423251869698
+    - rid: 1904270922169188354
+      type: {class: PhysicsCallbacks2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
+      data:
+        CallbackFlags:
+          Value: 4095
+    - rid: 1904270922169188355
+      type: {class: CullablePrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
+      data:
+        Offset:
+          X:
+            RawValue: 0
+          Y:
+            RawValue: 16384
+        BroadRadius:
+          RawValue: 32768
+    - rid: 1904270922169188356
+      type: {class: EnemyPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
+      data:
+        Spawnpoint:
+          X:
+            RawValue: -344064
+          Y:
+            RawValue: 32768
+        IgnorePlayerWhenRespawning:
+          Value: 0
+        DisableRespawning:
+          Value: 0
+    - rid: 1904270922169188357
+      type: {class: FreezablePrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
+      data:
+        IceBlockSize:
+          X:
+            RawValue: 42598
+          Y:
+            RawValue: 42598
+        AutoBreakFrames: 180
+        AutoBreakGrabAdditionalFrames: 0
+        AutoBreakWhileHeld:
+          Value: 0
+        Offset:
+          X:
+            RawValue: 0
+          Y:
+            RawValue: 0
+        IsCarryable:
+          Value: 1
+        IsFlying:
+          Value: 0
+    - rid: 1904270922169188358
+      type: {class: GoombaPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
+      data:
+        Speed:
+          RawValue: 57344
+    - rid: 1904270922169188359
+      type: {class: InteractablePrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
+      data:
+        ColliderDisabled:
+          Value: 0
+    - rid: 1904270922169188360
+      type: {class: InteractionInitiatorPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
+      data:
+        _empty_prototype_dummy_field_: 0
+    - rid: 1904270922169188361
+      type: {class: PhysicsObjectPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
+      data:
+        Gravity:
+          X:
+            RawValue: 0
+          Y:
+            RawValue: -1409024
+        TerminalVelocity:
+          RawValue: -524288
+        IsFrozen:
+          Value: 0
+        DisableCollision:
+          Value: 0
+        SlowInLiquids:
+          Value: 1
+        IsWaterSolid:
+          Value: 0
+        BreakMegaObjects:
+          Value: 0
+    - rid: 1904270922169188362
+      type: {class: WrappingObjectPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
+      data:
+        _empty_prototype_dummy_field_: 0
+    - rid: 2967068392109899776
+      type: {class: Transform2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
+      data:
+        Position:
+          X:
+            RawValue: 606208
+          Y:
+            RawValue: 212992
+        Rotation:
+          RawValue: 0
+    - rid: 2967068392109899777
+      type: {class: PhysicsCollider2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
+      data:
+        ShapeConfig:
+          ShapeType: 4
+          PolygonCollider:
+            Id:
+              Value: 0
+          CircleRadius:
+            RawValue: 0
+          CapsuleSize:
+            X:
+              RawValue: 0
+            Y:
+              RawValue: 0
+          EdgeExtent:
+            RawValue: 0
+          BoxExtents:
+            X:
+              RawValue: 14336
+            Y:
+              RawValue: 16384
+          PositionOffset:
+            X:
+              RawValue: 0
+            Y:
+              RawValue: 0
+          RotationOffset:
+            RawValue: 0
+          UserTag: 0
+          IsPersistent: 1
+          CompoundShapes: []
+        Layer: 9
+        IsTrigger: 1
+        PhysicsMaterial:
+          Id:
+            Value: 0
+    - rid: 2967068392109899778
       type: {class: PhysicsCallbacks2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
       data:
         CallbackFlags:
           Value: 0
-    - rid: 1218192423251869699
-      type: {class: BreakableObjectPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
+    - rid: 2967068392109899779
+      type: {class: CoinPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
       data:
-        OriginalHeight:
-          RawValue: 196608
-        MinimumHeight:
-          RawValue: 0
-        IsStompable:
+        CoinType:
           Value: 1
-    - rid: 1812743607870816256
+        Lifetime: 0
+        UncollectableFrames: 0
+    - rid: 2967068392109899780
+      type: {class: CullablePrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
+      data:
+        Offset:
+          X:
+            RawValue: 0
+          Y:
+            RawValue: 0
+        BroadRadius:
+          RawValue: 26214
+    - rid: 2967068392109899781
+      type: {class: InteractablePrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
+      data:
+        ColliderDisabled:
+          Value: 0
+    - rid: 3395932105807495168
+      type: {class: Transform2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
+      data:
+        Position:
+          X:
+            RawValue: 16384
+          Y:
+            RawValue: 212992
+        Rotation:
+          RawValue: 0
+    - rid: 3395932105807495169
+      type: {class: PhysicsCollider2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
+      data:
+        ShapeConfig:
+          ShapeType: 4
+          PolygonCollider:
+            Id:
+              Value: 0
+          CircleRadius:
+            RawValue: 0
+          CapsuleSize:
+            X:
+              RawValue: 0
+            Y:
+              RawValue: 0
+          EdgeExtent:
+            RawValue: 0
+          BoxExtents:
+            X:
+              RawValue: 14336
+            Y:
+              RawValue: 16384
+          PositionOffset:
+            X:
+              RawValue: 0
+            Y:
+              RawValue: 0
+          RotationOffset:
+            RawValue: 0
+          UserTag: 0
+          IsPersistent: 1
+          CompoundShapes: []
+        Layer: 9
+        IsTrigger: 1
+        PhysicsMaterial:
+          Id:
+            Value: 0
+    - rid: 3395932105807495170
+      type: {class: PhysicsCallbacks2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
+      data:
+        CallbackFlags:
+          Value: 0
+    - rid: 3395932105807495171
+      type: {class: CoinPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
+      data:
+        CoinType:
+          Value: 1
+        Lifetime: 0
+        UncollectableFrames: 0
+    - rid: 3395932105807495172
+      type: {class: CullablePrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
+      data:
+        Offset:
+          X:
+            RawValue: 0
+          Y:
+            RawValue: 0
+        BroadRadius:
+          RawValue: 26214
+    - rid: 3395932105807495173
+      type: {class: InteractablePrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
+      data:
+        ColliderDisabled:
+          Value: 0
+    - rid: 4446608830146543616
+      type: {class: Transform2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
+      data:
+        Position:
+          X:
+            RawValue: 49152
+          Y:
+            RawValue: 212992
+        Rotation:
+          RawValue: 0
+    - rid: 4446608830146543617
+      type: {class: PhysicsCollider2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
+      data:
+        ShapeConfig:
+          ShapeType: 4
+          PolygonCollider:
+            Id:
+              Value: 0
+          CircleRadius:
+            RawValue: 0
+          CapsuleSize:
+            X:
+              RawValue: 0
+            Y:
+              RawValue: 0
+          EdgeExtent:
+            RawValue: 0
+          BoxExtents:
+            X:
+              RawValue: 14336
+            Y:
+              RawValue: 16384
+          PositionOffset:
+            X:
+              RawValue: 0
+            Y:
+              RawValue: 0
+          RotationOffset:
+            RawValue: 0
+          UserTag: 0
+          IsPersistent: 1
+          CompoundShapes: []
+        Layer: 9
+        IsTrigger: 1
+        PhysicsMaterial:
+          Id:
+            Value: 0
+    - rid: 4446608830146543618
+      type: {class: PhysicsCallbacks2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
+      data:
+        CallbackFlags:
+          Value: 0
+    - rid: 4446608830146543619
+      type: {class: CoinPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
+      data:
+        CoinType:
+          Value: 1
+        Lifetime: 0
+        UncollectableFrames: 0
+    - rid: 4446608830146543620
+      type: {class: CullablePrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
+      data:
+        Offset:
+          X:
+            RawValue: 0
+          Y:
+            RawValue: 0
+        BroadRadius:
+          RawValue: 26214
+    - rid: 4446608830146543621
+      type: {class: InteractablePrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
+      data:
+        ColliderDisabled:
+          Value: 0
+    - rid: 4573175170545483776
+      type: {class: Transform2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
+      data:
+        Position:
+          X:
+            RawValue: 573440
+          Y:
+            RawValue: 212992
+        Rotation:
+          RawValue: 0
+    - rid: 4573175170545483777
+      type: {class: PhysicsCollider2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
+      data:
+        ShapeConfig:
+          ShapeType: 4
+          PolygonCollider:
+            Id:
+              Value: 0
+          CircleRadius:
+            RawValue: 0
+          CapsuleSize:
+            X:
+              RawValue: 0
+            Y:
+              RawValue: 0
+          EdgeExtent:
+            RawValue: 0
+          BoxExtents:
+            X:
+              RawValue: 14336
+            Y:
+              RawValue: 16384
+          PositionOffset:
+            X:
+              RawValue: 0
+            Y:
+              RawValue: 0
+          RotationOffset:
+            RawValue: 0
+          UserTag: 0
+          IsPersistent: 1
+          CompoundShapes: []
+        Layer: 9
+        IsTrigger: 1
+        PhysicsMaterial:
+          Id:
+            Value: 0
+    - rid: 4573175170545483778
+      type: {class: PhysicsCallbacks2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
+      data:
+        CallbackFlags:
+          Value: 0
+    - rid: 4573175170545483779
+      type: {class: CoinPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
+      data:
+        CoinType:
+          Value: 1
+        Lifetime: 0
+        UncollectableFrames: 0
+    - rid: 4573175170545483780
+      type: {class: CullablePrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
+      data:
+        Offset:
+          X:
+            RawValue: 0
+          Y:
+            RawValue: 0
+        BroadRadius:
+          RawValue: 26214
+    - rid: 4573175170545483781
+      type: {class: InteractablePrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
+      data:
+        ColliderDisabled:
+          Value: 0
+    - rid: 5636341017683689472
+      type: {class: Transform2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
+      data:
+        Position:
+          X:
+            RawValue: -606208
+          Y:
+            RawValue: 32768
+        Rotation:
+          RawValue: 0
+    - rid: 5636341017683689473
+      type: {class: PhysicsCollider2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
+      data:
+        ShapeConfig:
+          ShapeType: 4
+          PolygonCollider:
+            Id:
+              Value: 0
+          CircleRadius:
+            RawValue: 0
+          CapsuleSize:
+            X:
+              RawValue: 0
+            Y:
+              RawValue: 0
+          EdgeExtent:
+            RawValue: 0
+          BoxExtents:
+            X:
+              RawValue: 9830
+            Y:
+              RawValue: 13107
+          PositionOffset:
+            X:
+              RawValue: 0
+            Y:
+              RawValue: 13173
+          RotationOffset:
+            RawValue: 0
+          UserTag: 0
+          IsPersistent: 1
+          CompoundShapes: []
+        Layer: 9
+        IsTrigger: 0
+        PhysicsMaterial:
+          Id:
+            Value: 0
+    - rid: 5636341017683689474
+      type: {class: PhysicsCallbacks2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
+      data:
+        CallbackFlags:
+          Value: 4095
+    - rid: 5636341017683689475
+      type: {class: CullablePrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
+      data:
+        Offset:
+          X:
+            RawValue: 0
+          Y:
+            RawValue: 16384
+        BroadRadius:
+          RawValue: 32768
+    - rid: 5636341017683689476
+      type: {class: EnemyPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
+      data:
+        Spawnpoint:
+          X:
+            RawValue: -606208
+          Y:
+            RawValue: 32768
+        IgnorePlayerWhenRespawning:
+          Value: 0
+        DisableRespawning:
+          Value: 0
+    - rid: 5636341017683689477
+      type: {class: FreezablePrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
+      data:
+        IceBlockSize:
+          X:
+            RawValue: 42598
+          Y:
+            RawValue: 42598
+        AutoBreakFrames: 180
+        AutoBreakGrabAdditionalFrames: 0
+        AutoBreakWhileHeld:
+          Value: 0
+        Offset:
+          X:
+            RawValue: 0
+          Y:
+            RawValue: 0
+        IsCarryable:
+          Value: 1
+        IsFlying:
+          Value: 0
+    - rid: 5636341017683689478
+      type: {class: GoombaPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
+      data:
+        Speed:
+          RawValue: 57344
+    - rid: 5636341017683689479
+      type: {class: InteractablePrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
+      data:
+        ColliderDisabled:
+          Value: 0
+    - rid: 5636341017683689480
+      type: {class: InteractionInitiatorPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
+      data:
+        _empty_prototype_dummy_field_: 0
+    - rid: 5636341017683689481
+      type: {class: PhysicsObjectPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
+      data:
+        Gravity:
+          X:
+            RawValue: 0
+          Y:
+            RawValue: -1409024
+        TerminalVelocity:
+          RawValue: -524288
+        IsFrozen:
+          Value: 0
+        DisableCollision:
+          Value: 0
+        SlowInLiquids:
+          Value: 1
+        IsWaterSolid:
+          Value: 0
+        BreakMegaObjects:
+          Value: 0
+    - rid: 5636341017683689482
+      type: {class: WrappingObjectPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
+      data:
+        _empty_prototype_dummy_field_: 0
+    - rid: 6570762336053755904
+      type: {class: Transform2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
+      data:
+        Position:
+          X:
+            RawValue: -442368
+          Y:
+            RawValue: 278528
+        Rotation:
+          RawValue: 0
+    - rid: 6570762336053755905
+      type: {class: PhysicsCollider2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
+      data:
+        ShapeConfig:
+          ShapeType: 4
+          PolygonCollider:
+            Id:
+              Value: 0
+          CircleRadius:
+            RawValue: 0
+          CapsuleSize:
+            X:
+              RawValue: 0
+            Y:
+              RawValue: 0
+          EdgeExtent:
+            RawValue: 0
+          BoxExtents:
+            X:
+              RawValue: 14336
+            Y:
+              RawValue: 16384
+          PositionOffset:
+            X:
+              RawValue: 0
+            Y:
+              RawValue: 0
+          RotationOffset:
+            RawValue: 0
+          UserTag: 0
+          IsPersistent: 1
+          CompoundShapes: []
+        Layer: 9
+        IsTrigger: 1
+        PhysicsMaterial:
+          Id:
+            Value: 0
+    - rid: 6570762336053755906
+      type: {class: PhysicsCallbacks2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
+      data:
+        CallbackFlags:
+          Value: 0
+    - rid: 6570762336053755907
+      type: {class: CoinPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
+      data:
+        CoinType:
+          Value: 1
+        Lifetime: 0
+        UncollectableFrames: 0
+    - rid: 6570762336053755908
+      type: {class: CullablePrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
+      data:
+        Offset:
+          X:
+            RawValue: 0
+          Y:
+            RawValue: 0
+        BroadRadius:
+          RawValue: 26214
+    - rid: 6570762336053755909
+      type: {class: InteractablePrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
+      data:
+        ColliderDisabled:
+          Value: 0
+    - rid: 7515263985617207296
       type: {class: Transform2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
       data:
         Position:
@@ -298,7 +1006,7 @@ MonoBehaviour:
             RawValue: 32768
         Rotation:
           RawValue: 0
-    - rid: 1812743607870816257
+    - rid: 7515263985617207297
       type: {class: PhysicsCollider2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
       data:
         ShapeConfig:
@@ -335,16 +1043,16 @@ MonoBehaviour:
         PhysicsMaterial:
           Id:
             Value: 0
-    - rid: 1812743607870816258
+    - rid: 7515263985617207298
       type: {class: PhysicsCallbacks2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
       data:
         CallbackFlags:
           Value: 4095
-    - rid: 1812743607870816259
+    - rid: 7515263985617207299
       type: {class: ComboKeeperPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
       data:
         Combo: 0
-    - rid: 1812743607870816260
+    - rid: 7515263985617207300
       type: {class: CullablePrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
       data:
         Offset:
@@ -354,7 +1062,7 @@ MonoBehaviour:
             RawValue: 26214
         BroadRadius:
           RawValue: 39322
-    - rid: 1812743607870816261
+    - rid: 7515263985617207301
       type: {class: EnemyPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
       data:
         Spawnpoint:
@@ -366,7 +1074,7 @@ MonoBehaviour:
           Value: 0
         DisableRespawning:
           Value: 0
-    - rid: 1812743607870816262
+    - rid: 7515263985617207302
       type: {class: FreezablePrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
       data:
         IceBlockSize:
@@ -387,21 +1095,21 @@ MonoBehaviour:
           Value: 1
         IsFlying:
           Value: 0
-    - rid: 1812743607870816263
+    - rid: 7515263985617207303
       type: {class: HoldablePrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
       data:
         HoldAboveHead:
           Value: 0
-    - rid: 1812743607870816264
+    - rid: 7515263985617207304
       type: {class: InteractablePrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
       data:
         ColliderDisabled:
           Value: 0
-    - rid: 1812743607870816265
+    - rid: 7515263985617207305
       type: {class: InteractionInitiatorPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
       data:
         _empty_prototype_dummy_field_: 0
-    - rid: 1812743607870816266
+    - rid: 7515263985617207306
       type: {class: KoopaPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
       data:
         SpawnPowerupWhenStomped:
@@ -425,7 +1133,7 @@ MonoBehaviour:
             RawValue: 39322
           Y:
             RawValue: 65536
-    - rid: 1812743607870816267
+    - rid: 7515263985617207307
       type: {class: PhysicsObjectPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
       data:
         Gravity:
@@ -445,21 +1153,21 @@ MonoBehaviour:
           Value: 0
         BreakMegaObjects:
           Value: 0
-    - rid: 1812743607870816268
+    - rid: 7515263985617207308
       type: {class: WrappingObjectPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
       data:
         _empty_prototype_dummy_field_: 0
-    - rid: 3383382073929629696
+    - rid: 7960537994111221760
       type: {class: Transform2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
       data:
         Position:
           X:
-            RawValue: -606208
+            RawValue: -393216
           Y:
             RawValue: 32768
         Rotation:
           RawValue: 0
-    - rid: 3383382073929629697
+    - rid: 7960537994111221761
       type: {class: PhysicsCollider2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
       data:
         ShapeConfig:
@@ -478,333 +1186,39 @@ MonoBehaviour:
             RawValue: 0
           BoxExtents:
             X:
-              RawValue: 9830
+              RawValue: 32768
             Y:
-              RawValue: 13107
+              RawValue: 49152
           PositionOffset:
             X:
               RawValue: 0
             Y:
-              RawValue: 13173
+              RawValue: 49152
           RotationOffset:
             RawValue: 0
           UserTag: 0
           IsPersistent: 1
           CompoundShapes: []
-        Layer: 9
+        Layer: 0
         IsTrigger: 0
         PhysicsMaterial:
           Id:
             Value: 0
-    - rid: 3383382073929629698
+    - rid: 7960537994111221762
       type: {class: PhysicsCallbacks2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
       data:
         CallbackFlags:
-          Value: 4095
-    - rid: 3383382073929629699
-      type: {class: CullablePrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
-      data:
-        Offset:
-          X:
-            RawValue: 0
-          Y:
-            RawValue: 16384
-        BroadRadius:
-          RawValue: 32768
-    - rid: 3383382073929629700
-      type: {class: EnemyPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
-      data:
-        Spawnpoint:
-          X:
-            RawValue: -606208
-          Y:
-            RawValue: 32768
-        IgnorePlayerWhenRespawning:
           Value: 0
-        DisableRespawning:
-          Value: 0
-    - rid: 3383382073929629701
-      type: {class: FreezablePrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
+    - rid: 7960537994111221763
+      type: {class: BreakableObjectPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
       data:
-        IceBlockSize:
-          X:
-            RawValue: 42598
-          Y:
-            RawValue: 42598
-        AutoBreakFrames: 180
-        AutoBreakGrabAdditionalFrames: 0
-        AutoBreakWhileHeld:
-          Value: 0
-        Offset:
-          X:
-            RawValue: 0
-          Y:
-            RawValue: 0
-        IsCarryable:
-          Value: 1
-        IsFlying:
-          Value: 0
-    - rid: 3383382073929629702
-      type: {class: GoombaPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
-      data:
-        Speed:
-          RawValue: 57344
-    - rid: 3383382073929629703
-      type: {class: InteractablePrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
-      data:
-        ColliderDisabled:
-          Value: 0
-    - rid: 3383382073929629704
-      type: {class: InteractionInitiatorPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
-      data:
-        _empty_prototype_dummy_field_: 0
-    - rid: 3383382073929629705
-      type: {class: PhysicsObjectPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
-      data:
-        Gravity:
-          X:
-            RawValue: 0
-          Y:
-            RawValue: -1409024
-        TerminalVelocity:
-          RawValue: -524288
-        IsFrozen:
-          Value: 0
-        DisableCollision:
-          Value: 0
-        SlowInLiquids:
-          Value: 1
-        IsWaterSolid:
-          Value: 0
-        BreakMegaObjects:
-          Value: 0
-    - rid: 3383382073929629706
-      type: {class: WrappingObjectPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
-      data:
-        _empty_prototype_dummy_field_: 0
-    - rid: 4891817686134161408
-      type: {class: Transform2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
-      data:
-        Position:
-          X:
-            RawValue: -507904
-          Y:
-            RawValue: 278528
-        Rotation:
+        OriginalHeight:
+          RawValue: 196608
+        MinimumHeight:
           RawValue: 0
-    - rid: 4891817686134161409
-      type: {class: PhysicsCollider2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
-      data:
-        ShapeConfig:
-          ShapeType: 4
-          PolygonCollider:
-            Id:
-              Value: 0
-          CircleRadius:
-            RawValue: 0
-          CapsuleSize:
-            X:
-              RawValue: 0
-            Y:
-              RawValue: 0
-          EdgeExtent:
-            RawValue: 0
-          BoxExtents:
-            X:
-              RawValue: 14336
-            Y:
-              RawValue: 16384
-          PositionOffset:
-            X:
-              RawValue: 0
-            Y:
-              RawValue: 0
-          RotationOffset:
-            RawValue: 0
-          UserTag: 0
-          IsPersistent: 1
-          CompoundShapes: []
-        Layer: 9
-        IsTrigger: 1
-        PhysicsMaterial:
-          Id:
-            Value: 0
-    - rid: 4891817686134161410
-      type: {class: PhysicsCallbacks2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
-      data:
-        CallbackFlags:
-          Value: 0
-    - rid: 4891817686134161411
-      type: {class: CoinPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
-      data:
-        CoinType:
+        IsStompable:
           Value: 1
-        Lifetime: 0
-        UncollectableFrames: 0
-    - rid: 4891817686134161412
-      type: {class: CullablePrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
-      data:
-        Offset:
-          X:
-            RawValue: 0
-          Y:
-            RawValue: 0
-        BroadRadius:
-          RawValue: 26214
-    - rid: 4891817686134161413
-      type: {class: InteractablePrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
-      data:
-        ColliderDisabled:
-          Value: 0
-    - rid: 5292839420364324864
-      type: {class: Transform2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
-      data:
-        Position:
-          X:
-            RawValue: 16384
-          Y:
-            RawValue: 212992
-        Rotation:
-          RawValue: 0
-    - rid: 5292839420364324865
-      type: {class: PhysicsCollider2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
-      data:
-        ShapeConfig:
-          ShapeType: 4
-          PolygonCollider:
-            Id:
-              Value: 0
-          CircleRadius:
-            RawValue: 0
-          CapsuleSize:
-            X:
-              RawValue: 0
-            Y:
-              RawValue: 0
-          EdgeExtent:
-            RawValue: 0
-          BoxExtents:
-            X:
-              RawValue: 14336
-            Y:
-              RawValue: 16384
-          PositionOffset:
-            X:
-              RawValue: 0
-            Y:
-              RawValue: 0
-          RotationOffset:
-            RawValue: 0
-          UserTag: 0
-          IsPersistent: 1
-          CompoundShapes: []
-        Layer: 9
-        IsTrigger: 1
-        PhysicsMaterial:
-          Id:
-            Value: 0
-    - rid: 5292839420364324866
-      type: {class: PhysicsCallbacks2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
-      data:
-        CallbackFlags:
-          Value: 0
-    - rid: 5292839420364324867
-      type: {class: CoinPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
-      data:
-        CoinType:
-          Value: 1
-        Lifetime: 0
-        UncollectableFrames: 0
-    - rid: 5292839420364324868
-      type: {class: CullablePrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
-      data:
-        Offset:
-          X:
-            RawValue: 0
-          Y:
-            RawValue: 0
-        BroadRadius:
-          RawValue: 26214
-    - rid: 5292839420364324869
-      type: {class: InteractablePrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
-      data:
-        ColliderDisabled:
-          Value: 0
-    - rid: 5634812294941638656
-      type: {class: Transform2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
-      data:
-        Position:
-          X:
-            RawValue: 606208
-          Y:
-            RawValue: 212992
-        Rotation:
-          RawValue: 0
-    - rid: 5634812294941638657
-      type: {class: PhysicsCollider2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
-      data:
-        ShapeConfig:
-          ShapeType: 4
-          PolygonCollider:
-            Id:
-              Value: 0
-          CircleRadius:
-            RawValue: 0
-          CapsuleSize:
-            X:
-              RawValue: 0
-            Y:
-              RawValue: 0
-          EdgeExtent:
-            RawValue: 0
-          BoxExtents:
-            X:
-              RawValue: 14336
-            Y:
-              RawValue: 16384
-          PositionOffset:
-            X:
-              RawValue: 0
-            Y:
-              RawValue: 0
-          RotationOffset:
-            RawValue: 0
-          UserTag: 0
-          IsPersistent: 1
-          CompoundShapes: []
-        Layer: 9
-        IsTrigger: 1
-        PhysicsMaterial:
-          Id:
-            Value: 0
-    - rid: 5634812294941638658
-      type: {class: PhysicsCallbacks2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
-      data:
-        CallbackFlags:
-          Value: 0
-    - rid: 5634812294941638659
-      type: {class: CoinPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
-      data:
-        CoinType:
-          Value: 1
-        Lifetime: 0
-        UncollectableFrames: 0
-    - rid: 5634812294941638660
-      type: {class: CullablePrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
-      data:
-        Offset:
-          X:
-            RawValue: 0
-          Y:
-            RawValue: 0
-        BroadRadius:
-          RawValue: 26214
-    - rid: 5634812294941638661
-      type: {class: InteractablePrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
-      data:
-        ColliderDisabled:
-          Value: 0
-    - rid: 6976460943924396032
+    - rid: 8862042412541804544
       type: {class: Transform2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
       data:
         Position:
@@ -814,7 +1228,7 @@ MonoBehaviour:
             RawValue: 32768
         Rotation:
           RawValue: 0
-    - rid: 6976460943924396033
+    - rid: 8862042412541804545
       type: {class: PhysicsCollider2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
       data:
         ShapeConfig:
@@ -851,12 +1265,12 @@ MonoBehaviour:
         PhysicsMaterial:
           Id:
             Value: 0
-    - rid: 6976460943924396034
+    - rid: 8862042412541804546
       type: {class: PhysicsCallbacks2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
       data:
         CallbackFlags:
           Value: 0
-    - rid: 6976460943924396035
+    - rid: 8862042412541804547
       type: {class: BreakableObjectPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
       data:
         OriginalHeight:
@@ -865,140 +1279,7 @@ MonoBehaviour:
           RawValue: 0
         IsStompable:
           Value: 1
-    - rid: 7792369256158461952
-      type: {class: Transform2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
-      data:
-        Position:
-          X:
-            RawValue: -344064
-          Y:
-            RawValue: 32768
-        Rotation:
-          RawValue: 0
-    - rid: 7792369256158461953
-      type: {class: PhysicsCollider2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
-      data:
-        ShapeConfig:
-          ShapeType: 4
-          PolygonCollider:
-            Id:
-              Value: 0
-          CircleRadius:
-            RawValue: 0
-          CapsuleSize:
-            X:
-              RawValue: 0
-            Y:
-              RawValue: 0
-          EdgeExtent:
-            RawValue: 0
-          BoxExtents:
-            X:
-              RawValue: 9830
-            Y:
-              RawValue: 13107
-          PositionOffset:
-            X:
-              RawValue: 0
-            Y:
-              RawValue: 13173
-          RotationOffset:
-            RawValue: 0
-          UserTag: 0
-          IsPersistent: 1
-          CompoundShapes: []
-        Layer: 9
-        IsTrigger: 0
-        PhysicsMaterial:
-          Id:
-            Value: 0
-    - rid: 7792369256158461954
-      type: {class: PhysicsCallbacks2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
-      data:
-        CallbackFlags:
-          Value: 4095
-    - rid: 7792369256158461955
-      type: {class: CullablePrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
-      data:
-        Offset:
-          X:
-            RawValue: 0
-          Y:
-            RawValue: 16384
-        BroadRadius:
-          RawValue: 32768
-    - rid: 7792369256158461956
-      type: {class: EnemyPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
-      data:
-        Spawnpoint:
-          X:
-            RawValue: -344064
-          Y:
-            RawValue: 32768
-        IgnorePlayerWhenRespawning:
-          Value: 0
-        DisableRespawning:
-          Value: 0
-    - rid: 7792369256158461957
-      type: {class: FreezablePrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
-      data:
-        IceBlockSize:
-          X:
-            RawValue: 42598
-          Y:
-            RawValue: 42598
-        AutoBreakFrames: 180
-        AutoBreakGrabAdditionalFrames: 0
-        AutoBreakWhileHeld:
-          Value: 0
-        Offset:
-          X:
-            RawValue: 0
-          Y:
-            RawValue: 0
-        IsCarryable:
-          Value: 1
-        IsFlying:
-          Value: 0
-    - rid: 7792369256158461958
-      type: {class: GoombaPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
-      data:
-        Speed:
-          RawValue: 57344
-    - rid: 7792369256158461959
-      type: {class: InteractablePrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
-      data:
-        ColliderDisabled:
-          Value: 0
-    - rid: 7792369256158461960
-      type: {class: InteractionInitiatorPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
-      data:
-        _empty_prototype_dummy_field_: 0
-    - rid: 7792369256158461961
-      type: {class: PhysicsObjectPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
-      data:
-        Gravity:
-          X:
-            RawValue: 0
-          Y:
-            RawValue: -1409024
-        TerminalVelocity:
-          RawValue: -524288
-        IsFrozen:
-          Value: 0
-        DisableCollision:
-          Value: 0
-        SlowInLiquids:
-          Value: 1
-        IsWaterSolid:
-          Value: 0
-        BreakMegaObjects:
-          Value: 0
-    - rid: 7792369256158461962
-      type: {class: WrappingObjectPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
-      data:
-        _empty_prototype_dummy_field_: 0
-    - rid: 8091843171643817984
+    - rid: 9081208219925217280
       type: {class: Transform2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
       data:
         Position:
@@ -1008,7 +1289,7 @@ MonoBehaviour:
             RawValue: 147456
         Rotation:
           RawValue: 0
-    - rid: 8091843171643817985
+    - rid: 9081208219925217281
       type: {class: PhysicsCollider2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
       data:
         ShapeConfig:
@@ -1045,12 +1326,12 @@ MonoBehaviour:
         PhysicsMaterial:
           Id:
             Value: 0
-    - rid: 8091843171643817986
+    - rid: 9081208219925217282
       type: {class: PhysicsCallbacks2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
       data:
         CallbackFlags:
           Value: 0
-    - rid: 8091843171643817987
+    - rid: 9081208219925217283
       type: {class: InvisibleBlockPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
       data:
         BumpTile:
@@ -1059,284 +1340,3 @@ MonoBehaviour:
         Tile:
           Id:
             Value: 520268055672688161
-    - rid: 8401615228999041024
-      type: {class: Transform2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
-      data:
-        Position:
-          X:
-            RawValue: 573440
-          Y:
-            RawValue: 212992
-        Rotation:
-          RawValue: 0
-    - rid: 8401615228999041025
-      type: {class: PhysicsCollider2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
-      data:
-        ShapeConfig:
-          ShapeType: 4
-          PolygonCollider:
-            Id:
-              Value: 0
-          CircleRadius:
-            RawValue: 0
-          CapsuleSize:
-            X:
-              RawValue: 0
-            Y:
-              RawValue: 0
-          EdgeExtent:
-            RawValue: 0
-          BoxExtents:
-            X:
-              RawValue: 14336
-            Y:
-              RawValue: 16384
-          PositionOffset:
-            X:
-              RawValue: 0
-            Y:
-              RawValue: 0
-          RotationOffset:
-            RawValue: 0
-          UserTag: 0
-          IsPersistent: 1
-          CompoundShapes: []
-        Layer: 9
-        IsTrigger: 1
-        PhysicsMaterial:
-          Id:
-            Value: 0
-    - rid: 8401615228999041026
-      type: {class: PhysicsCallbacks2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
-      data:
-        CallbackFlags:
-          Value: 0
-    - rid: 8401615228999041027
-      type: {class: CoinPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
-      data:
-        CoinType:
-          Value: 1
-        Lifetime: 0
-        UncollectableFrames: 0
-    - rid: 8401615228999041028
-      type: {class: CullablePrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
-      data:
-        Offset:
-          X:
-            RawValue: 0
-          Y:
-            RawValue: 0
-        BroadRadius:
-          RawValue: 26214
-    - rid: 8401615228999041029
-      type: {class: InteractablePrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
-      data:
-        ColliderDisabled:
-          Value: 0
-    - rid: 8499690517292908544
-      type: {class: Transform2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
-      data:
-        Position:
-          X:
-            RawValue: -442368
-          Y:
-            RawValue: 278528
-        Rotation:
-          RawValue: 0
-    - rid: 8499690517292908545
-      type: {class: PhysicsCollider2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
-      data:
-        ShapeConfig:
-          ShapeType: 4
-          PolygonCollider:
-            Id:
-              Value: 0
-          CircleRadius:
-            RawValue: 0
-          CapsuleSize:
-            X:
-              RawValue: 0
-            Y:
-              RawValue: 0
-          EdgeExtent:
-            RawValue: 0
-          BoxExtents:
-            X:
-              RawValue: 14336
-            Y:
-              RawValue: 16384
-          PositionOffset:
-            X:
-              RawValue: 0
-            Y:
-              RawValue: 0
-          RotationOffset:
-            RawValue: 0
-          UserTag: 0
-          IsPersistent: 1
-          CompoundShapes: []
-        Layer: 9
-        IsTrigger: 1
-        PhysicsMaterial:
-          Id:
-            Value: 0
-    - rid: 8499690517292908546
-      type: {class: PhysicsCallbacks2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
-      data:
-        CallbackFlags:
-          Value: 0
-    - rid: 8499690517292908547
-      type: {class: CoinPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
-      data:
-        CoinType:
-          Value: 1
-        Lifetime: 0
-        UncollectableFrames: 0
-    - rid: 8499690517292908548
-      type: {class: CullablePrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
-      data:
-        Offset:
-          X:
-            RawValue: 0
-          Y:
-            RawValue: 0
-        BroadRadius:
-          RawValue: 26214
-    - rid: 8499690517292908549
-      type: {class: InteractablePrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
-      data:
-        ColliderDisabled:
-          Value: 0
-    - rid: 8670111536095690752
-      type: {class: Transform2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
-      data:
-        Position:
-          X:
-            RawValue: 344064
-          Y:
-            RawValue: 294912
-        Rotation:
-          RawValue: 0
-    - rid: 8670111536095690753
-      type: {class: PhysicsCollider2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
-      data:
-        ShapeConfig:
-          ShapeType: 4
-          PolygonCollider:
-            Id:
-              Value: 0
-          CircleRadius:
-            RawValue: 0
-          CapsuleSize:
-            X:
-              RawValue: 0
-            Y:
-              RawValue: 0
-          EdgeExtent:
-            RawValue: 0
-          BoxExtents:
-            X:
-              RawValue: 9830
-            Y:
-              RawValue: 13107
-          PositionOffset:
-            X:
-              RawValue: 0
-            Y:
-              RawValue: 13173
-          RotationOffset:
-            RawValue: 0
-          UserTag: 0
-          IsPersistent: 1
-          CompoundShapes: []
-        Layer: 9
-        IsTrigger: 0
-        PhysicsMaterial:
-          Id:
-            Value: 0
-    - rid: 8670111536095690754
-      type: {class: PhysicsCallbacks2DPrototype, ns: Quantum.Prototypes, asm: Quantum.Engine}
-      data:
-        CallbackFlags:
-          Value: 4095
-    - rid: 8670111536095690755
-      type: {class: CullablePrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
-      data:
-        Offset:
-          X:
-            RawValue: 0
-          Y:
-            RawValue: 16384
-        BroadRadius:
-          RawValue: 32768
-    - rid: 8670111536095690756
-      type: {class: EnemyPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
-      data:
-        Spawnpoint:
-          X:
-            RawValue: 344064
-          Y:
-            RawValue: 294912
-        IgnorePlayerWhenRespawning:
-          Value: 0
-        DisableRespawning:
-          Value: 0
-    - rid: 8670111536095690757
-      type: {class: FreezablePrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
-      data:
-        IceBlockSize:
-          X:
-            RawValue: 42598
-          Y:
-            RawValue: 42598
-        AutoBreakFrames: 180
-        AutoBreakGrabAdditionalFrames: 0
-        AutoBreakWhileHeld:
-          Value: 0
-        Offset:
-          X:
-            RawValue: 0
-          Y:
-            RawValue: 0
-        IsCarryable:
-          Value: 1
-        IsFlying:
-          Value: 0
-    - rid: 8670111536095690758
-      type: {class: GoombaPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
-      data:
-        Speed:
-          RawValue: 57344
-    - rid: 8670111536095690759
-      type: {class: InteractablePrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
-      data:
-        ColliderDisabled:
-          Value: 0
-    - rid: 8670111536095690760
-      type: {class: InteractionInitiatorPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
-      data:
-        _empty_prototype_dummy_field_: 0
-    - rid: 8670111536095690761
-      type: {class: PhysicsObjectPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
-      data:
-        Gravity:
-          X:
-            RawValue: 0
-          Y:
-            RawValue: -1409024
-        TerminalVelocity:
-          RawValue: -524288
-        IsFrozen:
-          Value: 0
-        DisableCollision:
-          Value: 0
-        SlowInLiquids:
-          Value: 1
-        IsWaterSolid:
-          Value: 0
-        BreakMegaObjects:
-          Value: 0
-    - rid: 8670111536095690762
-      type: {class: WrappingObjectPrototype, ns: Quantum.Prototypes, asm: Quantum.Simulation}
-      data:
-        _empty_prototype_dummy_field_: 0

--- a/Assets/QuantumUser/AssetObjects/Maps/Grass/DefaultGrassStageData.asset
+++ b/Assets/QuantumUser/AssetObjects/Maps/Grass/DefaultGrassStageData.asset
@@ -67,8 +67,7 @@ MonoBehaviour:
     B: 170
     A: 255
   HidePlayersOnMinimap: 0
-  SpawnBigPowerups: 1
-  SpawnVerticalPowerups: 1
+  BannedPowerUPs: []
   SfxOverrides: []
   MainMusic:
   - Id:

--- a/Assets/QuantumUser/AssetObjects/Maps/Jungle/CustomJungleStageData.asset
+++ b/Assets/QuantumUser/AssetObjects/Maps/Jungle/CustomJungleStageData.asset
@@ -67,8 +67,8 @@ MonoBehaviour:
     B: 44
     A: 255
   HidePlayersOnMinimap: 0
-  SpawnBigPowerups: 0
-  SpawnVerticalPowerups: 1
+  BannedPowerUPs:
+  - {fileID: 11400000, guid: 348238c0b7671f944aaa8b9d272994f5, type: 2}
   SfxOverrides: []
   MainMusic:
   - Id:

--- a/Assets/QuantumUser/AssetObjects/Maps/Volcano/CustomVolcanoStageData.asset
+++ b/Assets/QuantumUser/AssetObjects/Maps/Volcano/CustomVolcanoStageData.asset
@@ -67,8 +67,8 @@ MonoBehaviour:
     B: 0
     A: 255
   HidePlayersOnMinimap: 0
-  SpawnBigPowerups: 0
-  SpawnVerticalPowerups: 1
+  BannedPowerUPs:
+  - {fileID: 11400000, guid: 348238c0b7671f944aaa8b9d272994f5, type: 2}
   SfxOverrides: []
   MainMusic:
   - Id:

--- a/Assets/QuantumUser/AssetObjects/Maps/Volcano/CustomVolcanoStageData.asset
+++ b/Assets/QuantumUser/AssetObjects/Maps/Volcano/CustomVolcanoStageData.asset
@@ -68,7 +68,7 @@ MonoBehaviour:
     A: 255
   HidePlayersOnMinimap: 0
   BannedPowerUPs:
-  - {fileID: 11400000, guid: 348238c0b7671f944aaa8b9d272994f5, type: 2}
+  - {fileID: 11400000, guid: 2f5b677c66fff0c409c7e88879d71249, type: 2}
   SfxOverrides: []
   MainMusic:
   - Id:

--- a/Assets/QuantumUser/Editor/QuantumGameGizmosSettings.asset
+++ b/Assets/QuantumUser/Editor/QuantumGameGizmosSettings.asset
@@ -63,6 +63,14 @@ MonoBehaviour:
         _value: 0
       DisableFill:
         _value: 0
+    ParametricInertiaShape:
+      Enabled: 1
+      Color: {r: 1, g: 0.92156863, b: 0.015686275, a: 0.25}
+      Scale: 0
+      OnlyDrawSelected:
+        _value: 1
+      DisableFill:
+        _value: 0
     AsleepColliders:
       Enabled: 1
       Color: {r: 0.5192922, g: 0.4622621, b: 0.6985294, a: 0.5}
@@ -75,6 +83,14 @@ MonoBehaviour:
       Enabled: 1
       Color: {r: 0.5, g: 0.5, b: 0.5, a: 0.5}
       Scale: 0
+      OnlyDrawSelected:
+        _value: 0
+      DisableFill:
+        _value: 0
+    CenterOfMass:
+      Enabled: 0
+      Color: {r: 1, g: 0, b: 0.5, a: 0.5}
+      Scale: 0.1
       OnlyDrawSelected:
         _value: 0
       DisableFill:
@@ -181,6 +197,7 @@ MonoBehaviour:
         _value: 1
       DisableFill:
         _value: 0
+      DrawTriangleId: 0
     NavMeshVertexNormals:
       Enabled: 0
       Color: {r: 1, g: 0.92156863, b: 0.015686275, a: 1}

--- a/Assets/QuantumUser/Resources/AssetObjects.meta
+++ b/Assets/QuantumUser/Resources/AssetObjects.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: b3d56614e9ff0e94a8b7797c3b6aad71
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/QuantumUser/Resources/AssetObjects/Maps.meta
+++ b/Assets/QuantumUser/Resources/AssetObjects/Maps.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c227b27417b27c34dafac45670083f1f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/QuantumUser/Resources/AssetObjects/Maps/A.meta
+++ b/Assets/QuantumUser/Resources/AssetObjects/Maps/A.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 734b2bdd99117c548bea9b17e844c88b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/CoinItem/CoinItemAsset.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/CoinItem/CoinItemAsset.cs
@@ -20,15 +20,20 @@ public class CoinItemAsset : AssetObject {
     public SoundEffect BlockSpawnSoundEffect = SoundEffect.World_Block_Powerup;
     public TypeFlags Flags = TypeFlags.None;
     public int MaxNumberOfItems = 0;
-    public int MaxMatchingPowerStates = 0; // no more items with a matching powerUP state will spawn if above 0
 
     public FPVector2 CameraSpawnOffset = new(0, FP.FromString("1.68"));
-    
-    public virtual unsafe int CountItemsExisting(Frame f) {
-        return 0;
-    }
 
-    public virtual unsafe int CountPlayersWithState(Frame f) {
-        return 0;
+    public virtual unsafe bool SpecialSpawnConditions(Frame f) {
+        if (MaxNumberOfItems > 0) {
+            int numOfItems = 0;
+            foreach ((var _, var foundItem) in f.Unsafe.GetComponentBlockIterator<CoinItem>()) {
+                if (foundItem->Scriptable == this) {
+                    numOfItems++;
+                }
+            }
+
+            return numOfItems < MaxNumberOfItems;
+        }
+        return true;
     }
 }

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/CoinItem/CoinItemAsset.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/CoinItem/CoinItemAsset.cs
@@ -1,14 +1,34 @@
+using System;
 using Photon.Deterministic;
 using Quantum;
 
 public class CoinItemAsset : AssetObject {
+    [Flags]
+    public enum TypeFlags {
+        None = 0,
+        BigPower = 1 << 0,
+        VerticalPower = 1 << 1,
+        Custom = 1 << 2,
+        LivesOnly = 1 << 3,
+        BlockOnly = 1 << 4,
+        RouletteOnly = 1 << 5,
+        NotPowerUP = 1 << 6,
+        NoStateChange = 1 << 7,
+    }
     public AssetRef<EntityPrototype> Prefab;
     public FP SpawnChance = FP._0_10, AboveAverageBonus = 0, BelowAverageBonus = 0;
     public SoundEffect BlockSpawnSoundEffect = SoundEffect.World_Block_Powerup;
-    public bool BigPowerup, VerticalPowerup, CustomPowerup, LivesOnlyPowerup;
-    public bool CanSpawnFromBlock = true;
-    public bool OnlyOneCanExist = false;
+    public TypeFlags Flags = TypeFlags.None;
+    public int MaxNumberOfItems = 0;
+    public int MaxMatchingPowerStates = 0; // no more items with a matching powerUP state will spawn if above 0
 
     public FPVector2 CameraSpawnOffset = new(0, FP.FromString("1.68"));
+    
+    public virtual unsafe int CountItemsExisting(Frame f) {
+        return 0;
+    }
 
+    public virtual unsafe int CountPlayersWithState(Frame f) {
+        return 0;
+    }
 }

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/CoinItem/CoinItemAsset.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/CoinItem/CoinItemAsset.cs
@@ -5,7 +5,7 @@ public class CoinItemAsset : AssetObject {
     public AssetRef<EntityPrototype> Prefab;
     public FP SpawnChance = FP._0_10, AboveAverageBonus = 0, BelowAverageBonus = 0;
     public SoundEffect BlockSpawnSoundEffect = SoundEffect.World_Block_Powerup;
-    public bool CustomPowerup, LivesOnlyPowerup;
+    public bool BigPowerup, VerticalPowerup, CustomPowerup, LivesOnlyPowerup;
     public bool CanSpawnFromBlock = true;
     public bool OnlyOneCanExist = false;
 

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/CoinItem/CoinItemAsset.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/CoinItem/CoinItemAsset.cs
@@ -6,14 +6,15 @@ public class CoinItemAsset : AssetObject {
     [Flags]
     public enum TypeFlags {
         None = 0,
-        BigPower = 1 << 0,
-        VerticalPower = 1 << 1,
+        Big = 1 << 0,
+        Vertical = 1 << 1,
         Custom = 1 << 2,
         LivesOnly = 1 << 3,
-        BlockOnly = 1 << 4,
-        RouletteOnly = 1 << 5,
+        Block = 1 << 4,
+        Roulette = 1 << 5,
         NotPowerUP = 1 << 6,
         NoStateChange = 1 << 7,
+        Disadvantage = 1 << 8,
     }
     public AssetRef<EntityPrototype> Prefab;
     public FP SpawnChance = FP._0_10, AboveAverageBonus = 0, BelowAverageBonus = 0;

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/CoinItem/CoinItemAsset.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/CoinItem/CoinItemAsset.cs
@@ -2,11 +2,10 @@ using Photon.Deterministic;
 using Quantum;
 
 public class CoinItemAsset : AssetObject {
-
     public AssetRef<EntityPrototype> Prefab;
-    public FP SpawnChance = FP._0_10, LosingSpawnBonus = 0;
+    public FP SpawnChance = FP._0_10, AboveAverageBonus = 0, BelowAverageBonus = 0;
     public SoundEffect BlockSpawnSoundEffect = SoundEffect.World_Block_Powerup;
-    public bool BigPowerup, VerticalPowerup, CustomPowerup, LivesOnlyPowerup;
+    public bool CustomPowerup, LivesOnlyPowerup;
     public bool CanSpawnFromBlock = true;
     public bool OnlyOneCanExist = false;
 

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Powerup/MegaMushroomPowerupAsset.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Powerup/MegaMushroomPowerupAsset.cs
@@ -4,16 +4,23 @@ using Quantum;
 public class MegaMushroomPowerupAsset : PowerupAsset {
 
     public FP GrowAnimationDuration = FP._1_50;
-    public override unsafe int CountPlayersWithState(Frame f) {
+    public unsafe int CountMegaPlayers(Frame f) {
         int playersWithPower = 0;
         foreach ((var _, var otherPlayer) in f.Unsafe.GetComponentBlockIterator<MarioPlayer>()) {
-            // check if another player matches the powerUP state
             if (otherPlayer->CurrentPowerupState == PowerupState.MegaMushroom && otherPlayer->MegaMushroomStartFrames == 0) {
                 playersWithPower++;
             }
         }
         return playersWithPower;
     }
+
+    public override unsafe bool SpecialSpawnConditions(Frame f) {
+        var megaPlayers = CountMegaPlayers(f);
+        if (MaxMatchingPowerStates > 0 && megaPlayers > MaxMatchingPowerStates) { return false; }
+
+        return true;
+    }
+
 
     protected override unsafe void OnCollected(Frame f, EntityRef marioEntity) {
         var mario = f.Unsafe.GetPointer<MarioPlayer>(marioEntity);

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Powerup/MegaMushroomPowerupAsset.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Powerup/MegaMushroomPowerupAsset.cs
@@ -4,6 +4,16 @@ using Quantum;
 public class MegaMushroomPowerupAsset : PowerupAsset {
 
     public FP GrowAnimationDuration = FP._1_50;
+    public override unsafe int CountPlayersWithState(Frame f) {
+        int playersWithPower = 0;
+        foreach ((var _, var otherPlayer) in f.Unsafe.GetComponentBlockIterator<MarioPlayer>()) {
+            // check if another player matches the powerUP state
+            if (otherPlayer->CurrentPowerupState == PowerupState.MegaMushroom && otherPlayer->MegaMushroomStartFrames == 0) {
+                playersWithPower++;
+            }
+        }
+        return playersWithPower;
+    }
 
     protected override unsafe void OnCollected(Frame f, EntityRef marioEntity) {
         var mario = f.Unsafe.GetPointer<MarioPlayer>(marioEntity);

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Powerup/PowerupAsset.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Powerup/PowerupAsset.cs
@@ -40,6 +40,25 @@ public class PowerupAsset : CoinItemAsset, ISoundOverrideProvider {
             }
         }
     }
+    public override unsafe int CountItemsExisting(Frame f) {
+        int numOfItems = 0;
+        foreach ((var _, var foundItem) in f.Unsafe.GetComponentBlockIterator<CoinItem>()) {
+            if (f.FindAsset(foundItem->Scriptable).Equals(this)) {
+                numOfItems++;
+            }
+        }
+        return numOfItems;
+    }
+    public override unsafe int CountPlayersWithState(Frame f) {
+        int playersWithPower = 0;
+        foreach ((var _, var otherPlayers) in f.Unsafe.GetComponentBlockIterator<MarioPlayer>()) {
+            // check if another player matches the powerUP state
+            if (otherPlayers->CurrentPowerupState == State) {
+                playersWithPower++;
+            }
+        }
+        return playersWithPower;
+    }
 
     public SoundEffectOverride GetOverride(SoundEffect sfx) {
         overridesDict.TryGetValue(sfx, out var result);

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Powerup/PowerupAsset.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Powerup/PowerupAsset.cs
@@ -5,6 +5,8 @@ using System.Collections.Generic;
 
 public class PowerupAsset : CoinItemAsset, ISoundOverrideProvider {
 
+    public int MaxMatchingPowerStates = 0;
+    public int MaxMatchingReserveState = 0;
     public PowerupState State;
 
     public bool SoundPlaysEverywhere;
@@ -40,24 +42,46 @@ public class PowerupAsset : CoinItemAsset, ISoundOverrideProvider {
             }
         }
     }
-    public override unsafe int CountItemsExisting(Frame f) {
+    public unsafe int CountItemsExisting(Frame f) {
         int numOfItems = 0;
         foreach ((var _, var foundItem) in f.Unsafe.GetComponentBlockIterator<CoinItem>()) {
-            if (f.FindAsset(foundItem->Scriptable).Equals(this)) {
+            if (f.FindAsset(foundItem->Scriptable) == this) {
                 numOfItems++;
             }
         }
         return numOfItems;
     }
-    public override unsafe int CountPlayersWithState(Frame f) {
+    public unsafe int CountPlayersWithState(Frame f) {
         int playersWithPower = 0;
-        foreach ((var _, var otherPlayers) in f.Unsafe.GetComponentBlockIterator<MarioPlayer>()) {
+        foreach ((var _, var otherPlayer) in f.Unsafe.GetComponentBlockIterator<MarioPlayer>()) {
             // check if another player matches the powerUP state
-            if (otherPlayers->CurrentPowerupState == State) {
+            if (otherPlayer->CurrentPowerupState == State) {
                 playersWithPower++;
             }
         }
         return playersWithPower;
+    }
+    public unsafe int CountPlayersWithReserve(Frame f) {
+        int playersWithPower = 0;
+        foreach ((var _, var otherPlayer) in f.Unsafe.GetComponentBlockIterator<MarioPlayer>()) {
+            // check if the powerUP asset in reserve matches us
+            if (otherPlayer->ReserveItem == this) {
+                playersWithPower++;
+            }
+        }
+        return playersWithPower;
+    }
+    public override bool SpecialSpawnConditions(Frame f) {
+        var existingItems = CountItemsExisting(f);
+        if (MaxNumberOfItems > 0 && existingItems >= MaxNumberOfItems) { return false; }
+
+        var playersWithState = CountPlayersWithState(f);
+        if (MaxMatchingPowerStates > 0 && playersWithState >= MaxMatchingPowerStates) { return false; }
+
+        var playersWithReserve = CountPlayersWithReserve(f);
+        if (MaxMatchingReserveState > 0 && playersWithReserve >= MaxMatchingReserveState) { return false; }
+
+        return true;
     }
 
     public SoundEffectOverride GetOverride(SoundEffect sfx) {

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Powerup/StarmanPowerupAsset.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Powerup/StarmanPowerupAsset.cs
@@ -5,17 +5,9 @@ public class StarmanPowerupAsset : PowerupAsset {
 
     public FP StarmanDuration = 10;
 
-    public override unsafe int CountPlayersWithState(Frame f) {
-        int playersWithPower = 0;
-        foreach ((var _, var otherPlayers) in f.Unsafe.GetComponentBlockIterator<MarioPlayer>()) {
-            // check if another player matches the powerUP state
-            if (otherPlayers->InvincibilityFrames > 0) {
-                playersWithPower++;
-            }
-        }
-        return playersWithPower;
+    public override bool SpecialSpawnConditions(Frame f) {
+        return true; // no restrictions
     }
-
 
     public override unsafe PowerupReserveResult Collect(Frame f, EntityRef marioEntity) {
         var mario = f.Unsafe.GetPointer<MarioPlayer>(marioEntity);

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Powerup/StarmanPowerupAsset.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Powerup/StarmanPowerupAsset.cs
@@ -5,6 +5,18 @@ public class StarmanPowerupAsset : PowerupAsset {
 
     public FP StarmanDuration = 10;
 
+    public override unsafe int CountPlayersWithState(Frame f) {
+        int playersWithPower = 0;
+        foreach ((var _, var otherPlayers) in f.Unsafe.GetComponentBlockIterator<MarioPlayer>()) {
+            // check if another player matches the powerUP state
+            if (otherPlayers->InvincibilityFrames > 0) {
+                playersWithPower++;
+            }
+        }
+        return playersWithPower;
+    }
+
+
     public override unsafe PowerupReserveResult Collect(Frame f, EntityRef marioEntity) {
         var mario = f.Unsafe.GetPointer<MarioPlayer>(marioEntity);
         mario->InvincibilityFrames = (ushort) (StarmanDuration * f.UpdateRate);

--- a/Assets/QuantumUser/Simulation/NSMB/Gamemode/CoinRunnersGamemode.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Gamemode/CoinRunnersGamemode.cs
@@ -1,5 +1,6 @@
 using Photon.Deterministic;
 using System;
+using static UnityEditor.Progress;
 
 namespace Quantum {
     public unsafe class CoinRunnersGamemode : GamemodeAsset {
@@ -87,11 +88,12 @@ namespace Quantum {
             return gamemodeDataCopy.CoinRunners->ObjectiveCoins;
         }
 
-        public override FP GetItemSpawnWeight(Frame f, CoinItemAsset coinItem, int leaderCoins, int ourCoins) {
-            FP coinDifference = leaderCoins - ourCoins;
+        public override FP GetItemSpawnWeight(Frame f, CoinItemAsset item, FP averageCoins, int ourCoins) {
+            FP avgDiff = ourCoins - averageCoins;
             FP percentageTimeRemaining = f.Global->Timer / (f.Global->Rules.TimerMinutes * 60);
-            FP bonus = coinItem.LosingSpawnBonus * FPMath.Log((coinDifference / 40) + 1, FP.E) * 1 - (percentageTimeRemaining * percentageTimeRemaining);
-            return FPMath.Max(0, coinItem.SpawnChance + bonus);
+            FP whichBonus = avgDiff > 0 ? item.AboveAverageBonus : item.BelowAverageBonus;
+            FP bonus = whichBonus * FPMath.Log((FPMath.Abs(avgDiff) / 40) + 1, FP.E) * 1 - (percentageTimeRemaining * percentageTimeRemaining);
+            return FPMath.Max(0, item.SpawnChance + bonus);
         }
     }
 }

--- a/Assets/QuantumUser/Simulation/NSMB/Gamemode/CoinRunnersGamemode.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Gamemode/CoinRunnersGamemode.cs
@@ -1,6 +1,5 @@
 using Photon.Deterministic;
 using System;
-using static UnityEditor.Progress;
 
 namespace Quantum {
     public unsafe class CoinRunnersGamemode : GamemodeAsset {

--- a/Assets/QuantumUser/Simulation/NSMB/Gamemode/GamemodeAsset.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Gamemode/GamemodeAsset.cs
@@ -30,12 +30,7 @@ namespace Quantum {
             if (flag.HasFlag(CoinItemAsset.TypeFlags.Custom) &! rules.CustomPowerupsEnabled) { return false; }
             if (flag.HasFlag(CoinItemAsset.TypeFlags.RouletteOnly) && fromBlock) { return false; }
             if (flag.HasFlag(CoinItemAsset.TypeFlags.BlockOnly) &! fromBlock) { return false; }
-            if (coinItem.MaxNumberOfItems > 0 && coinItem.CountItemsExisting(f) > coinItem.MaxNumberOfItems) {
-                return false;
-            }
-            if (coinItem.MaxMatchingPowerStates > 0 && coinItem.CountPlayersWithState(f) > coinItem.MaxMatchingPowerStates) {
-                return false;
-            }
+            if (!coinItem.SpecialSpawnConditions(f)) { return false; }
             if (coinItem is PowerupAsset powerUP) {
                 var stage = f.FindAsset<VersusStageData>(f.Map.UserAsset);
                 PowerupAsset[] bannedPowerUPs = stage.BannedPowerUPs;
@@ -188,10 +183,10 @@ namespace Quantum {
 
             int sum = 0;
             foreach (int objectiveCount in teamObjectives) {
-                sum += objectiveCount;
+                if (objectiveCount > 0) sum += objectiveCount;
             }
-
-            return ((FP)sum / aliveTeamCount);
+            UnityEngine.Debug.Log($"Sum {sum} Alive count {aliveTeamCount}");
+            return (FP)sum / aliveTeamCount;
         }
 
         public virtual EntityRef SpawnLooseCoin(Frame f, FPVector2 position) {

--- a/Assets/QuantumUser/Simulation/NSMB/Gamemode/GamemodeAsset.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Gamemode/GamemodeAsset.cs
@@ -201,12 +201,21 @@ namespace Quantum {
             Span<int> teamObjectives = stackalloc int[Constants.MaxPlayers];
             GetAllTeamsObjectiveCounts(f, teamObjectives);
 
+            int aliveTeamCount = 0;
+            int aliveTeam = -1;
+            for (int i = 0; i < teamObjectives.Length; i++) {
+                if (teamObjectives[i] > -1) {
+                    aliveTeamCount++;
+                    aliveTeam = i;
+                }
+            }
+
             int sum = 0;
             foreach (int objectiveCount in teamObjectives) {
                 sum += objectiveCount;
             }
 
-            return ((FP)sum / f.PlayerConnectedCount);
+            return ((FP)sum / aliveTeamCount);
         }
 
         public virtual EntityRef SpawnLooseCoin(Frame f, FPVector2 position) {

--- a/Assets/QuantumUser/Simulation/NSMB/Gamemode/GamemodeAsset.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Gamemode/GamemodeAsset.cs
@@ -28,8 +28,8 @@ namespace Quantum {
             var flag = coinItem.Flags;
             var rules = f.Global->Rules;
             if (flag.HasFlag(CoinItemAsset.TypeFlags.Custom) &! rules.CustomPowerupsEnabled) { return false; }
-            if (flag.HasFlag(CoinItemAsset.TypeFlags.RouletteOnly) && fromBlock) { return false; }
-            if (flag.HasFlag(CoinItemAsset.TypeFlags.BlockOnly) &! fromBlock) { return false; }
+            if (flag.HasFlag(CoinItemAsset.TypeFlags.Roulette) && fromBlock) { return false; }
+            if (flag.HasFlag(CoinItemAsset.TypeFlags.Block) &! fromBlock) { return false; }
             if (!coinItem.SpecialSpawnConditions(f)) { return false; }
             if (coinItem is PowerupAsset powerUP) {
                 var stage = f.FindAsset<VersusStageData>(f.Map.UserAsset);
@@ -185,7 +185,6 @@ namespace Quantum {
             foreach (int objectiveCount in teamObjectives) {
                 if (objectiveCount > 0) sum += objectiveCount;
             }
-            UnityEngine.Debug.Log($"Sum {sum} Alive count {aliveTeamCount}");
             return (FP)sum / aliveTeamCount;
         }
 

--- a/Assets/QuantumUser/Simulation/NSMB/Gamemode/GamemodeAsset.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Gamemode/GamemodeAsset.cs
@@ -1,6 +1,7 @@
 using Photon.Deterministic;
 using Quantum.Prototypes;
 using System;
+using System.Linq;
 
 namespace Quantum {
     public abstract unsafe class GamemodeAsset : AssetObject {
@@ -29,13 +30,12 @@ namespace Quantum {
             // "Losing" variable based on ln(x+1)
 
             int ourObjectiveCount = GetTeamObjectiveCount(f, mario->GetTeam(f)) ?? 0;
-            int leaderObjectiveCount = GetFirstPlaceObjectiveCount(f);
+            FP averageObjectiveCount = GetAverageObjectiveCount(f);
 
             var rules = f.Global->Rules;
+            PowerupAsset[] bannedPowerUPs = stage.BannedPowerUPs;
             bool custom = rules.CustomPowerupsEnabled;
             bool lives = rules.IsLivesEnabled;
-            bool big = stage.SpawnBigPowerups;
-            bool vertical = stage.SpawnVerticalPowerups;
 
             bool canSpawnMega = true;
 
@@ -64,16 +64,18 @@ namespace Quantum {
                     continue;
                 }
 
-                if ((coinItem.BigPowerup && !big)
-                    || (coinItem.VerticalPowerup && !vertical)
-                    || (coinItem.CustomPowerup && !custom)
+                if ((coinItem is PowerupAsset powerUP) && bannedPowerUPs.Any(p => p == powerUP)) {
+                    continue;
+                }
+
+                if ((coinItem.CustomPowerup && !custom)
                     || (coinItem.LivesOnlyPowerup && !lives)
                     || (!coinItem.CanSpawnFromBlock && fromBlock)
                     || (coinItem.OnlyOneCanExist && onlyOneAlreadyExists)) {
                     continue;
                 }
 
-                totalChance += GetItemSpawnWeight(f, coinItem, leaderObjectiveCount, ourObjectiveCount);
+                totalChance += GetItemSpawnWeight(f, coinItem, averageObjectiveCount, ourObjectiveCount);
             }
 
             FP rand = mario->RNG.Next(0, totalChance);
@@ -83,16 +85,18 @@ namespace Quantum {
                     continue;
                 }
 
-                if ((coinItem.BigPowerup && !big)
-                    || (coinItem.VerticalPowerup && !vertical)
-                    || (coinItem.CustomPowerup && !custom)
+                if ((coinItem is PowerupAsset powerUP) && bannedPowerUPs.Any(p => p == powerUP)) {
+                    continue;
+                }
+
+                if ((coinItem.CustomPowerup && !custom)
                     || (coinItem.LivesOnlyPowerup && !lives)
                     || (!coinItem.CanSpawnFromBlock && fromBlock)
                     || (coinItem.OnlyOneCanExist && onlyOneAlreadyExists)) {
                     continue;
                 }
 
-                FP chance = GetItemSpawnWeight(f, coinItem, leaderObjectiveCount, ourObjectiveCount);
+                FP chance = GetItemSpawnWeight(f, coinItem, averageObjectiveCount, ourObjectiveCount);
 
                 if (rand < chance) {
                     return coinItem;
@@ -104,7 +108,7 @@ namespace Quantum {
             return f.FindAsset(FallbackCoinItem);
         }
 
-        public abstract FP GetItemSpawnWeight(Frame f, CoinItemAsset item, int leaderObjectiveCount, int ourObjectiveCount);
+        public abstract FP GetItemSpawnWeight(Frame f, CoinItemAsset item, FP averageObjectiveCount, int ourObjectiveCount);
 
         public virtual int? GetWinningTeam(Frame f, out int winningObjectiveCount) {
             winningObjectiveCount = 0;
@@ -191,6 +195,18 @@ namespace Quantum {
             }
 
             return max;
+        }
+
+        public virtual FP GetAverageObjectiveCount(Frame f) {
+            Span<int> teamObjectives = stackalloc int[Constants.MaxPlayers];
+            GetAllTeamsObjectiveCounts(f, teamObjectives);
+
+            int sum = 0;
+            foreach (int objectiveCount in teamObjectives) {
+                sum += objectiveCount;
+            }
+
+            return ((FP)sum / f.PlayerConnectedCount);
         }
 
         public virtual EntityRef SpawnLooseCoin(Frame f, FPVector2 position) {

--- a/Assets/QuantumUser/Simulation/NSMB/Gamemode/GamemodeAsset.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Gamemode/GamemodeAsset.cs
@@ -24,6 +24,29 @@ namespace Quantum {
 
         public abstract int GetObjectiveCount(Frame f, MarioPlayer* mario);
 
+        public bool CanItemSpawn(Frame f, CoinItemAsset coinItem, bool fromBlock) {
+            var flag = coinItem.Flags;
+            var rules = f.Global->Rules;
+            if (flag.HasFlag(CoinItemAsset.TypeFlags.Custom) &! rules.CustomPowerupsEnabled) { return false; }
+            if (flag.HasFlag(CoinItemAsset.TypeFlags.RouletteOnly) && fromBlock) { return false; }
+            if (flag.HasFlag(CoinItemAsset.TypeFlags.BlockOnly) &! fromBlock) { return false; }
+            if (coinItem.MaxNumberOfItems > 0 && coinItem.CountItemsExisting(f) > coinItem.MaxNumberOfItems) {
+                return false;
+            }
+            if (coinItem.MaxMatchingPowerStates > 0 && coinItem.CountPlayersWithState(f) > coinItem.MaxMatchingPowerStates) {
+                return false;
+            }
+            if (coinItem is PowerupAsset powerUP) {
+                var stage = f.FindAsset<VersusStageData>(f.Map.UserAsset);
+                PowerupAsset[] bannedPowerUPs = stage.BannedPowerUPs;
+                if (bannedPowerUPs.Any(p => p == powerUP)) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
         public virtual CoinItemAsset GetRandomItem(Frame f, MarioPlayer* mario, bool fromBlock) {
             var stage = f.FindAsset<VersusStageData>(f.Map.UserAsset);
 
@@ -32,46 +55,10 @@ namespace Quantum {
             int ourObjectiveCount = GetTeamObjectiveCount(f, mario->GetTeam(f)) ?? 0;
             FP averageObjectiveCount = GetAverageObjectiveCount(f);
 
-            var rules = f.Global->Rules;
-            PowerupAsset[] bannedPowerUPs = stage.BannedPowerUPs;
-            bool custom = rules.CustomPowerupsEnabled;
-            bool lives = rules.IsLivesEnabled;
-
-            bool canSpawnMega = true;
-
-
-            foreach ((var _, var otherPlayer) in f.Unsafe.GetComponentBlockIterator<MarioPlayer>()) {
-                // Check if another player is actively mega (not growing or shrinking)
-                if (otherPlayer->CurrentPowerupState == PowerupState.MegaMushroom
-                    && otherPlayer->MegaMushroomStartFrames == 0) {
-                    canSpawnMega = false;
-                    break;
-                }
-            }
-
-            bool onlyOneAlreadyExists = false;
-            foreach ((var _, var coinItem) in f.Unsafe.GetComponentBlockIterator<CoinItem>()) {
-                if (f.FindAsset(coinItem->Scriptable).OnlyOneCanExist) {
-                    onlyOneAlreadyExists = true;
-                    break;
-                }
-            }
-
             FP totalChance = 0;
             foreach (AssetRef<CoinItemAsset> coinItemAsset in AllCoinItems) {
                 CoinItemAsset coinItem = f.FindAsset(coinItemAsset);
-                if ((coinItem is PowerupAsset powerup) && powerup.State == PowerupState.MegaMushroom && !canSpawnMega) {
-                    continue;
-                }
-
-                if ((coinItem is PowerupAsset powerUP) && bannedPowerUPs.Any(p => p == powerUP)) {
-                    continue;
-                }
-
-                if ((coinItem.CustomPowerup && !custom)
-                    || (coinItem.LivesOnlyPowerup && !lives)
-                    || (!coinItem.CanSpawnFromBlock && fromBlock)
-                    || (coinItem.OnlyOneCanExist && onlyOneAlreadyExists)) {
+                if (!CanItemSpawn(f, coinItem, fromBlock)) {
                     continue;
                 }
 
@@ -81,18 +68,7 @@ namespace Quantum {
             FP rand = mario->RNG.Next(0, totalChance);
             foreach (AssetRef<CoinItemAsset> coinItemAsset in AllCoinItems) {
                 CoinItemAsset coinItem = f.FindAsset(coinItemAsset);
-                if ((coinItem is PowerupAsset powerup) && powerup.State == PowerupState.MegaMushroom && !canSpawnMega) {
-                    continue;
-                }
-
-                if ((coinItem is PowerupAsset powerUP) && bannedPowerUPs.Any(p => p == powerUP)) {
-                    continue;
-                }
-
-                if ((coinItem.CustomPowerup && !custom)
-                    || (coinItem.LivesOnlyPowerup && !lives)
-                    || (!coinItem.CanSpawnFromBlock && fromBlock)
-                    || (coinItem.OnlyOneCanExist && onlyOneAlreadyExists)) {
+                if (!CanItemSpawn(f, coinItem, fromBlock)) {
                     continue;
                 }
 

--- a/Assets/QuantumUser/Simulation/NSMB/Gamemode/StarChasersGamemode.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Gamemode/StarChasersGamemode.cs
@@ -94,10 +94,11 @@ namespace Quantum {
             return gamemodeDataCopy.StarChasers->Stars;
         }
 
-        public override FP GetItemSpawnWeight(Frame f, CoinItemAsset item, int leaderStars, int ourStars) {
+        public override FP GetItemSpawnWeight(Frame f, CoinItemAsset item, FP starAverage, int ourStars) {
             int starsToWin = f.Global->Rules.StarsToWin;
-            int starDifference = leaderStars - ourStars;
-            FP bonus = item.LosingSpawnBonus * FPMath.Log(starDifference + 1, FP.E) * (FP._1 - ((FP) (starsToWin - leaderStars) / starsToWin));
+            FP avgDiff = ourStars - starAverage;
+            FP whichBonus = avgDiff > 0 ? item.AboveAverageBonus : item.BelowAverageBonus;
+            FP bonus = whichBonus * FPMath.Log(FPMath.Abs(avgDiff) + 1, FP.E) * (FP._1 - ((FP) (starsToWin - starAverage) / starsToWin));
             return FPMath.Max(0, item.SpawnChance + bonus);
         }
     }

--- a/Assets/QuantumUser/Simulation/NSMB/Map/VersusStageData.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Map/VersusStageData.cs
@@ -47,8 +47,7 @@ public unsafe class VersusStageData : AssetObject, ISoundOverrideProvider {
     public bool HidePlayersOnMinimap;
 
     [Header("-- Powerups")]
-    public bool SpawnBigPowerups = true;
-    public bool SpawnVerticalPowerups = true;
+    public PowerupAsset[] BannedPowerUPs;
 
     [Header("---Sound Overrides")]
     public SoundEffectOverride[] SfxOverrides;


### PR DESCRIPTION
Tackling my own issue #425 

PowerUPs now use averages, this also changes how stages ban powerUPs codewise using a list of banned powerUPs instead of two booleans.
The commit also cleans UP some code for calculating powerUP chances since the old way seems pretty tedious to figure out with some odd choices (such as having the same check confusing check twice instead of having a function handle everything). The new system also uses flags for spawned powerUPs.

For more details on this new powerUP formula see my spreadsheet.
https://docs.google.com/spreadsheets/d/1w0OOfNtDHt_1yZue5x9BfCYq6PbXRmh_Jt2UmW3Fadc/edit?gid=0#gid=0