### PR TITLE
implement enemies to home when offscreen

### DIFF
--- a/Assets/QuantumUser/Resources/EntityPrototypes/Enemy/BlueKoopa.prefab
+++ b/Assets/QuantumUser/Resources/EntityPrototypes/Enemy/BlueKoopa.prefab
@@ -13,6 +13,11 @@ PrefabInstance:
       propertyPath: m_SynchronizeParameters.Array.size
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 1004745928310103790, guid: 8cf8f49ac0882ed44953ea53ff901f11,
+        type: 3}
+      propertyPath: Prototype.StayAtHomeWhenOffscreen.Value
+      value: 1
+      objectReference: {fileID: 0}
     - target: {fileID: 1172164201446178320, guid: 8cf8f49ac0882ed44953ea53ff901f11,
         type: 3}
       propertyPath: Prototype.DontWalkOfLedges.Value

--- a/Assets/QuantumUser/Resources/EntityPrototypes/Enemy/Bobomb.prefab
+++ b/Assets/QuantumUser/Resources/EntityPrototypes/Enemy/Bobomb.prefab
@@ -651,6 +651,8 @@ MonoBehaviour:
       Value: 0
     DisableRespawning:
       Value: 0
+    StayAtHomeWhenOffscreen:
+      Value: 1
 --- !u!114 &724652125925019376
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/QuantumUser/Resources/EntityPrototypes/Enemy/Boo.prefab
+++ b/Assets/QuantumUser/Resources/EntityPrototypes/Enemy/Boo.prefab
@@ -344,6 +344,8 @@ MonoBehaviour:
       Value: 0
     DisableRespawning:
       Value: 0
+    StayAtHomeWhenOffscreen:
+      Value: 0
 --- !u!114 &5623453289331559766
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/QuantumUser/Resources/EntityPrototypes/Enemy/Goomba.prefab
+++ b/Assets/QuantumUser/Resources/EntityPrototypes/Enemy/Goomba.prefab
@@ -656,6 +656,8 @@ MonoBehaviour:
       Value: 0
     DisableRespawning:
       Value: 0
+    StayAtHomeWhenOffscreen:
+      Value: 1
 --- !u!114 &4848679844973023050
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/QuantumUser/Resources/EntityPrototypes/Enemy/Koopa.prefab
+++ b/Assets/QuantumUser/Resources/EntityPrototypes/Enemy/Koopa.prefab
@@ -683,6 +683,8 @@ MonoBehaviour:
       Value: 0
     DisableRespawning:
       Value: 0
+    StayAtHomeWhenOffscreen:
+      Value: 1
 --- !u!114 &-2274893890168952915
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/QuantumUser/Resources/EntityPrototypes/Enemy/Spiny.prefab
+++ b/Assets/QuantumUser/Resources/EntityPrototypes/Enemy/Spiny.prefab
@@ -510,6 +510,8 @@ MonoBehaviour:
       Value: 0
     DisableRespawning:
       Value: 0
+    StayAtHomeWhenOffscreen:
+      Value: 1
 --- !u!114 &8889607602468363306
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Enemy.qtn
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Enemy.qtn
@@ -1,7 +1,10 @@
+#define EnemyHomeRadius 12
+
 table component Enemy {
 	FPVector2 Spawnpoint;
 	bool IgnorePlayerWhenRespawning;
 	bool DisableRespawning;
+	bool StayAtHomeWhenOffscreen;
 
 	[ExcludeFromPrototype] bool IsActive;
 	[ExcludeFromPrototype] bool IsDead;
@@ -13,6 +16,7 @@ signal OnEnemyRespawned(EntityRef entity);
 signal OnEnemyEnemyCollision(EntityRef a, EntityRef b);
 signal OnEnemyKilledByStageReset(EntityRef entity);
 signal OnEnemyTurnaround(EntityRef entity);
+signal OnEnemyReturnedHome(EntityRef entity);
 
 enum EnemyKillReason : Byte {
 	Normal,

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/EnemySystem.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/EnemySystem.cs
@@ -1,5 +1,6 @@
 //#define MULTITHREADED
 
+using Photon.Deterministic;
 using Quantum.Task;
 
 namespace Quantum {
@@ -60,6 +61,8 @@ namespace Quantum {
                 }
                 return;
             }
+
+            if (enemy->StayAtHomeWhenOffscreen) OffscreenCheck(f, filter, stage);
         }
 
         public void SendSignalsTask(FrameThreadSafe f, int start, int count, void* arg) {
@@ -116,6 +119,8 @@ namespace Quantum {
                 f.Signals.OnEnemyDespawned(filter.Entity);
                 return;
             }
+
+            if (enemy->StayAtHomeWhenOffscreen) OffscreenCheck(f, filter, stage);
         }
 
 #endif
@@ -142,6 +147,25 @@ namespace Quantum {
             if (turnBoth) {
                 enemyB->ChangeFacingRight(f, entityB, !right);
             }
+        }
+
+        public void OffscreenCheck(Frame f, Filter filter, VersusStageData stage)
+        {
+            var allPlayersFilter = f.Filter<MarioPlayer, Transform2D>();
+            while (allPlayersFilter.NextUnsafe(out _, out _, out Transform2D* marioTransform)) {
+                QuantumUtils.WrappedDistance(stage, filter.Transform->Position, marioTransform->Position, out FP distance);
+                QuantumUtils.WrappedDistance(stage, filter.Enemy->Spawnpoint, marioTransform->Position, out FP spawnpointDistance);
+                if (FPMath.Abs(distance) < Constants.EnemyHomeRadius || FPMath.Abs(spawnpointDistance) < Constants.EnemyHomeRadius) return;
+            }
+
+            if (f.Unsafe.TryGetPointer(filter.Entity, out PhysicsObject* physicsObject))
+            {
+                if (physicsObject->IsFrozen) return;
+                physicsObject->Velocity = FPVector2.Zero;
+            }
+            if (filter.Transform->Position != filter.Enemy->Spawnpoint) f.Signals.OnEnemyReturnedHome(filter.Entity);
+            filter.Transform->Teleport(f, filter.Enemy->Spawnpoint);
+            filter.Enemy->FacingRight = false;
         }
 
         public void OnStageReset(Frame f, QBoolean full) {

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Koopa/KoopaSystem.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Koopa/KoopaSystem.cs
@@ -4,7 +4,7 @@ using Quantum.Collections;
 namespace Quantum {
     public unsafe class KoopaSystem : SystemMainThreadEntityFilter<Koopa, KoopaSystem.Filter>, ISignalOnThrowHoldable, ISignalOnEnemyRespawned, ISignalOnEntityBumped,
         ISignalOnBobombExplodeEntity, ISignalOnIceBlockBroken, ISignalOnEnemyKilledByStageReset, ISignalOnEnemyTurnaround, ISignalOnEntityCrushed,
-        ISignalOnMarioPlayerBecameInvincible {
+        ISignalOnMarioPlayerBecameInvincible, ISignalOnEnemyReturnedHome {
        
         public struct Filter {
             public EntityRef Entity;
@@ -523,6 +523,12 @@ namespace Quantum {
             var mario = f.Unsafe.GetPointer<MarioPlayer>(entity);
             if (f.Unsafe.TryGetPointer(mario->HeldEntity, out Koopa* koopa)) {
                 koopa->Kill(f, mario->HeldEntity, entity, EnemyKillReason.Special);
+            }
+        }
+
+        public void OnEnemyReturnedHome(Frame f, EntityRef entity) {
+            if (f.Unsafe.TryGetPointer(entity, out Koopa* koopa) && koopa->IsInShell) {
+                koopa->Respawn(f, entity);
             }
         }
         #endregion


### PR DESCRIPTION
[Linked suggestion](https://discord.com/channels/956396409731551263/1475537920319295649)

Enemies now have an "active" radius. If they get far (usually, when going off screen), they "despawn", returning to their initial position and stopping movement. When a player gets close enough to their spawnpoint (typically, a bit before appearing on screen), they start moving if they're alive. This is accurate to how they work in the OG games including NSMB and successive entries. Also, avoids situations where enemies have already moved "too much" by the time a player reaches them.