### PR TITLE
Ice Flower & Hammer Suit Tweaks

### DIFF
--- a/Assets/QuantumUser/Resources/EntityPrototypes/IceBlock.prefab
+++ b/Assets/QuantumUser/Resources/EntityPrototypes/IceBlock.prefab
@@ -642,7 +642,7 @@ SpriteRenderer:
   m_SortingOrder: 10
   m_MaskInteraction: 0
   m_Sprite: {fileID: 21300000, guid: 64d8b3652072ff942ad60637750783cc, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 0.5019608}
+  m_Color: {r: 1, g: 1, b: 1, a: 0.2509804}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 2

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/IceBlock/IceBlockBreakReason.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/IceBlock/IceBlockBreakReason.cs
@@ -4,6 +4,5 @@ public enum IceBlockBreakReason : byte {
     Groundpounded,
     BlockBump,
     HitWall,
-    Fireball,
     Other,
 }

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/IceBlock/IceBlockSystem.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/IceBlock/IceBlockSystem.cs
@@ -134,10 +134,10 @@ namespace Quantum {
                 if ((iceBlock->IsSliding && iceBlock->FacingRight == rightContact) || mario->IsInShell) {
                     var holdable = f.Unsafe.GetPointer<Holdable>(iceBlockEntity);
                     bool dropStars = !f.Unsafe.TryGetPointer(holdable->PreviousHolder, out MarioPlayer* holderMario) || mario->GetTeam(f) != holderMario->GetTeam(f);
-                    bool damaged = mario->DoKnockback(f, marioEntity, contact.Normal.X < 0, dropStars ? 1 : 0, KnockbackStrength.Normal, iceBlockEntity);
+                    bool damaged = mario->DoKnockback(f, marioEntity, contact.Normal.X < 0, dropStars ? 1 : 0, KnockbackStrength.FireballBump, iceBlockEntity);
                     if (damaged) {
                         FPVector2 particlePos = (f.Unsafe.GetPointer<Transform2D>(marioEntity)->Position + f.Unsafe.GetPointer<Transform2D>(iceBlockEntity)->Position) / 2;
-                        f.Events.PlayKnockbackEffect(marioEntity, iceBlockEntity, KnockbackStrength.Normal, particlePos);
+                        f.Events.PlayKnockbackEffect(marioEntity, iceBlockEntity, KnockbackStrength.FireballBump, particlePos);
                     }
 
                     Destroy(f, iceBlockEntity, IceBlockBreakReason.HitWall);
@@ -178,11 +178,6 @@ namespace Quantum {
 
         public static bool OnIceBlockProjectileInteraction(Frame f, EntityRef projectileEntity, EntityRef iceBlockEntity, PhysicsContact contact) {
             var projectileAsset = f.FindAsset(f.Unsafe.GetPointer<Projectile>(projectileEntity)->Asset);
-
-            if (projectileAsset.Effect == ProjectileEffectType.Fire) {
-                // Fireball: destroy
-                Destroy(f, iceBlockEntity, IceBlockBreakReason.Fireball);
-            }
 
             if (projectileAsset.DestroyOnHit) {
                 ProjectileSystem.Destroy(f, projectileEntity, projectileAsset.DestroyParticleEffect);

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayer.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayer.cs
@@ -540,7 +540,7 @@ namespace Quantum {
             KnockbackTick = f.Number;
 
             bool forceWeak = false;
-            if (freezable->IsFrozen(f) && strength != KnockbackStrength.Normal) {
+            if (freezable->IsFrozen(f) && strength != KnockbackStrength.Normal && strength != KnockbackStrength.Groundpound) {
                 forceWeak = true;
                 KnockbackTick -= 25;
             }

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayerSystem.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayerSystem.cs
@@ -2021,6 +2021,7 @@ namespace Quantum {
             }
 
             var mario = f.Unsafe.GetPointer<MarioPlayer>(marioEntity);
+            var marioPhysics = f.Unsafe.GetPointer<PhysicsObject>(marioEntity);
             var projectileAsset = f.FindAsset(projectile->Asset);
 
             bool dropStars = true;
@@ -2031,7 +2032,7 @@ namespace Quantum {
             bool damageable = !mario->IsInKnockback
                 && mario->CurrentPowerupState != PowerupState.MegaMushroom
                 && mario->IsDamageable
-                && !((mario->IsCrouchedInShell || mario->IsInShell) && projectileAsset.DoesntEffectBlueShell);
+                && !((mario->IsCrouchedInShell || mario->IsInShell) || (mario->CurrentPowerupState == PowerupState.HammerSuit && marioPhysics->IsTouchingGround && mario->IsCrouching) && projectileAsset.DoesntEffectBlueShell);
 
             if (damageable) {
                 bool didKnockback = false;
@@ -2399,15 +2400,6 @@ namespace Quantum {
                     defenderMario->DoKnockback(f, defender, !fromRight, 0, KnockbackStrength.Groundpound, attacker);
                 }
                 attackerMario->DoEntityBounce = false;
-            } else if (defenderMario->CurrentPowerupState == PowerupState.HammerSuit && defenderPhysicsObject->IsTouchingGround && defenderMario->IsCrouching && !groundpounded) {
-                // Bounce
-                var attackerPhysicsObject = f.Unsafe.GetPointer<PhysicsObject>(attacker);
-                if (FPMath.Abs(attackerPhysicsObject->Velocity.X) < 2) {
-                    attackerPhysicsObject->Velocity.X = fromRight ? -2 : 2;
-                }
-                attackerPhysicsObject->Velocity.Y = 4;
-                attackerMario->DoEntityBounce = false;
-                f.Events.EnemyKicked(defender, false);
             } else {
                 // Normal knockbacks
                 if (defenderMario->CurrentPowerupState == PowerupState.MiniMushroom && groundpounded) {
@@ -2578,31 +2570,37 @@ namespace Quantum {
             KnockbackStrength strength = KnockbackStrength.Normal;
             switch (breakReason) {
             case IceBlockBreakReason.HitWall:
-            case IceBlockBreakReason.BlockBump:
-            case IceBlockBreakReason.Fireball:
             case IceBlockBreakReason.Other:
-                // Soft knockback, 1 star
+                // Weak knockback, i-frames.
                 damaged = mario->DoKnockback(f, entity, mario->FacingRight, 1, (strength = KnockbackStrength.FireballBump), brokenIceBlock);
+                mario->DamageInvincibilityFrames = 120;
+                break;
+
+            case IceBlockBreakReason.BlockBump:
+                // Soft knockback, no i-frames.
+                damaged = mario->DoKnockback(f, entity, mario->FacingRight, 0, (strength = KnockbackStrength.Normal), brokenIceBlock);
                 break;
 
             case IceBlockBreakReason.Groundpounded:
-                // Hard knockback, 2 stars
-                damaged = mario->DoKnockback(f, entity, mario->FacingRight, 2, (strength = KnockbackStrength.Normal), brokenIceBlock);
+                // Hard knockback, i-frames.
+                damaged = mario->DoKnockback(f, entity, mario->FacingRight, 2, (strength = KnockbackStrength.Groundpound), brokenIceBlock);
+                mario->DamageInvincibilityFrames = 120;
                 break;
 
             case IceBlockBreakReason.Timer:
-                // Damage holder, if we can.
+                // Damage holder, if we can, and i-frames.
                 var iceBlockHoldable = f.Unsafe.GetPointer<Holdable>(brokenIceBlock);
                 if (f.Unsafe.TryGetPointer(iceBlockHoldable->Holder, out MarioPlayer* holderMario)) {
                     OnMarioMarioInteraction(f, entity, iceBlockHoldable->Holder);
+                    mario->DamageInvincibilityFrames = 120;
                 }
+                mario->DamageInvincibilityFrames = 120;
                 break;
             default:
                 // Fall through.
                 break;
             }
 
-            mario->DamageInvincibilityFrames = 120;
             if (damaged) {
                 FPVector2 particlePos = f.Unsafe.GetPointer<Transform2D>(brokenIceBlock)->Position;
                 particlePos.Y += iceBlock->Size.Y / 2;

--- a/Assets/Scripts/Entity/Player/MarioPlayerAnimator.cs
+++ b/Assets/Scripts/Entity/Player/MarioPlayerAnimator.cs
@@ -605,7 +605,7 @@ namespace NSMB.Entities.Player {
             propellerHelmet.SetActive(!DisableHeadwear && mario->CurrentPowerupState == PowerupState.PropellerMushroom);
             HammerHelm.SetActive(!DisableHeadwear && mario->CurrentPowerupState == PowerupState.HammerSuit && (!mario->IsCrouching || f.Exists(mario->CurrentPipe)));
             HammerShell.SetActive(mario->CurrentPowerupState == PowerupState.HammerSuit && (!mario->IsCrouching || f.Exists(mario->CurrentPipe)));
-            HammerTuck.SetActive(mario->CurrentPowerupState == PowerupState.HammerSuit && mario->IsCrouching && !f.Exists(mario->CurrentPipe));
+            HammerTuck.SetActive(mario->CurrentPowerupState == PowerupState.HammerSuit && mario->IsCrouching && marioPhysics->IstouchingGround!f.Exists(mario->CurrentPipe));
             
             Avatar targetAvatar = large ? largeAvatar : smallAvatar;
             bool changedAvatar = animator.avatar != targetAvatar;


### PR DESCRIPTION
- Tuck Shell model now only appears when you're touching the ground, making more sense visually (as you don't get protected when mid-air).
- Replaced stomp protection with projectile protection.
- Groundpounding frozen players will give them groundpound knockback.
- Ice Blocks are comboable.
- Blockbumping frozen players will give them stomp knockback, and will not immediately get them i-frames.
- Made the frozen cubes more transparent. It looks nicer.
- Ice Blocks can't be broken by Fireballs anymore (they are too fragile combining with how they break when picking up on slopes).