### PR TITLE
Rework Enemy Respawning System

### DIFF
--- a/Assets/QuantumUser/Resources/AssetObjects/Items/BlueShell.asset
+++ b/Assets/QuantumUser/Resources/AssetObjects/Items/BlueShell.asset
@@ -24,7 +24,7 @@ MonoBehaviour:
   AboveAverageBonus:
     RawValue: -49152
   BelowAverageBonus:
-    RawValue: 8192
+    RawValue: -32768
   BlockSpawnSoundEffect: 69
   Flags: 19
   MaxNumberOfItems: 0

--- a/Assets/QuantumUser/Resources/AssetObjects/Items/BlueShell.asset
+++ b/Assets/QuantumUser/Resources/AssetObjects/Items/BlueShell.asset
@@ -22,7 +22,7 @@ MonoBehaviour:
   SpawnChance:
     RawValue: 131072
   AboveAverageBonus:
-    RawValue: 16384
+    RawValue: -49152
   BelowAverageBonus:
     RawValue: 8192
   BlockSpawnSoundEffect: 69

--- a/Assets/QuantumUser/Resources/AssetObjects/Items/FireFlower.asset
+++ b/Assets/QuantumUser/Resources/AssetObjects/Items/FireFlower.asset
@@ -22,7 +22,7 @@ MonoBehaviour:
   SpawnChance:
     RawValue: 196608
   AboveAverageBonus:
-    RawValue: -81920
+    RawValue: -139264
   BelowAverageBonus:
     RawValue: 8192
   BlockSpawnSoundEffect: 69

--- a/Assets/QuantumUser/Resources/AssetObjects/Items/HammerSuit.asset
+++ b/Assets/QuantumUser/Resources/AssetObjects/Items/HammerSuit.asset
@@ -20,7 +20,7 @@ MonoBehaviour:
     Id:
       Value: 1472665878288241371
   SpawnChance:
-    RawValue: 196608
+    RawValue: 57344
   AboveAverageBonus:
     RawValue: -131072
   BelowAverageBonus:

--- a/Assets/QuantumUser/Resources/AssetObjects/Items/IceFlower.asset
+++ b/Assets/QuantumUser/Resources/AssetObjects/Items/IceFlower.asset
@@ -20,9 +20,9 @@ MonoBehaviour:
     Id:
       Value: 1524544283524633813
   SpawnChance:
-    RawValue: 196608
+    RawValue: 65536
   AboveAverageBonus:
-    RawValue: -163840
+    RawValue: -57344
   BelowAverageBonus:
     RawValue: 65536
   BlockSpawnSoundEffect: 69

--- a/Assets/QuantumUser/Resources/AssetObjects/Items/MegaMushroom.asset
+++ b/Assets/QuantumUser/Resources/AssetObjects/Items/MegaMushroom.asset
@@ -24,7 +24,7 @@ MonoBehaviour:
   AboveAverageBonus:
     RawValue: 0
   BelowAverageBonus:
-    RawValue: 278528
+    RawValue: 311296
   BlockSpawnSoundEffect: 99
   Flags: 3
   MaxNumberOfItems: 0

--- a/Assets/QuantumUser/Resources/AssetObjects/Items/MegaMushroom.asset
+++ b/Assets/QuantumUser/Resources/AssetObjects/Items/MegaMushroom.asset
@@ -24,7 +24,7 @@ MonoBehaviour:
   AboveAverageBonus:
     RawValue: 0
   BelowAverageBonus:
-    RawValue: 212992
+    RawValue: 278528
   BlockSpawnSoundEffect: 99
   Flags: 3
   MaxNumberOfItems: 0

--- a/Assets/QuantumUser/Resources/AssetObjects/Items/MiniMushroom.asset
+++ b/Assets/QuantumUser/Resources/AssetObjects/Items/MiniMushroom.asset
@@ -20,7 +20,7 @@ MonoBehaviour:
     Id:
       Value: 1414434856952255942
   SpawnChance:
-    RawValue: 65536
+    RawValue: 32768
   AboveAverageBonus:
     RawValue: 65536
   BelowAverageBonus:

--- a/Assets/QuantumUser/Resources/AssetObjects/Items/Mushroom.asset
+++ b/Assets/QuantumUser/Resources/AssetObjects/Items/Mushroom.asset
@@ -20,7 +20,7 @@ MonoBehaviour:
     Id:
       Value: 1268531089014898302
   SpawnChance:
-    RawValue: 98304
+    RawValue: 57344
   AboveAverageBonus:
     RawValue: 65536
   BelowAverageBonus:

--- a/Assets/QuantumUser/Resources/AssetObjects/Items/Starman.asset
+++ b/Assets/QuantumUser/Resources/AssetObjects/Items/Starman.asset
@@ -24,7 +24,7 @@ MonoBehaviour:
   AboveAverageBonus:
     RawValue: -57344
   BelowAverageBonus:
-    RawValue: 65536
+    RawValue: 98304
   BlockSpawnSoundEffect: 69
   Flags: 19
   MaxNumberOfItems: 0

--- a/Assets/QuantumUser/Resources/AssetObjects/Items/Starman.asset
+++ b/Assets/QuantumUser/Resources/AssetObjects/Items/Starman.asset
@@ -20,7 +20,7 @@ MonoBehaviour:
     Id:
       Value: 1502268950446962426
   SpawnChance:
-    RawValue: 57344
+    RawValue: 32768
   AboveAverageBonus:
     RawValue: -57344
   BelowAverageBonus:

--- a/Assets/QuantumUser/Resources/EntityPrototypes/Enemy/BlueKoopa.prefab
+++ b/Assets/QuantumUser/Resources/EntityPrototypes/Enemy/BlueKoopa.prefab
@@ -79,6 +79,32 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 22100000, guid: 8df73f9409b06d04190e8538ddfd3727,
         type: 2}
+    - target: {fileID: 5882114383898416491, guid: 8cf8f49ac0882ed44953ea53ff901f11,
+        type: 3}
+      propertyPath: respawnColor.a
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5882114383898416491, guid: 8cf8f49ac0882ed44953ea53ff901f11,
+        type: 3}
+      propertyPath: respawnColor.b
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5882114383898416491, guid: 8cf8f49ac0882ed44953ea53ff901f11,
+        type: 3}
+      propertyPath: respawnColor.g
+      value: 0.5647059
+      objectReference: {fileID: 0}
+    - target: {fileID: 5882114383898416491, guid: 8cf8f49ac0882ed44953ea53ff901f11,
+        type: 3}
+      propertyPath: respawnColor.r
+      value: 0.1176471
+      objectReference: {fileID: 0}
+    - target: {fileID: 5882114383898416491, guid: 8cf8f49ac0882ed44953ea53ff901f11,
+        type: 3}
+      propertyPath: respawnParticle
+      value: 
+      objectReference: {fileID: 5191653714546004373, guid: cb33e5df66c9644458081c1ddef24e6c,
+        type: 3}
     - target: {fileID: 7426856683177255952, guid: 8cf8f49ac0882ed44953ea53ff901f11,
         type: 3}
       propertyPath: m_SpriteTilingProperty.pivot.y

--- a/Assets/QuantumUser/Resources/EntityPrototypes/Enemy/Bobomb.prefab
+++ b/Assets/QuantumUser/Resources/EntityPrototypes/Enemy/Bobomb.prefab
@@ -442,6 +442,8 @@ MonoBehaviour:
   animator: {fileID: 8735478572021304808}
   explosionPrefab: {fileID: 1674080856964950978, guid: 7ac2c558b7c96304eb065980d84e1c67,
     type: 3}
+  respawnParticle: {fileID: 5191653714546004373, guid: cb33e5df66c9644458081c1ddef24e6c,
+    type: 3}
 --- !u!114 &6162738416106121865
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/QuantumUser/Resources/EntityPrototypes/Enemy/Goomba.prefab
+++ b/Assets/QuantumUser/Resources/EntityPrototypes/Enemy/Goomba.prefab
@@ -449,6 +449,8 @@ MonoBehaviour:
     type: 3}
   specialKillParticle: {fileID: 761201321277025702, guid: d0dec86b8ad08184d9da50d1f76fc7bd,
     type: 3}
+  respawnParticle: {fileID: 5191653714546004373, guid: cb33e5df66c9644458081c1ddef24e6c,
+    type: 3}
   legacyAnimation: {fileID: 2072787540995169967}
   sfx: {fileID: 6178880729858591457}
 --- !u!82 &5674404523704379184

--- a/Assets/QuantumUser/Resources/EntityPrototypes/Enemy/Koopa.prefab
+++ b/Assets/QuantumUser/Resources/EntityPrototypes/Enemy/Koopa.prefab
@@ -442,6 +442,9 @@ MonoBehaviour:
   sfx: {fileID: 3464633041449129214}
   sRenderer: {fileID: 8133877121043965814}
   rotation: {fileID: 8088900794427276647}
+  respawnParticle: {fileID: 5191653714546004373, guid: cb33e5df66c9644458081c1ddef24e6c,
+    type: 3}
+  respawnColor: {r: 0.4862745, g: 0.9882354, b: 0, a: 1}
   mirrorSprite: 0
   dontFlip: 0
 --- !u!82 &3399800873378663516

--- a/Assets/QuantumUser/Resources/EntityPrototypes/Enemy/RedKoopa.prefab
+++ b/Assets/QuantumUser/Resources/EntityPrototypes/Enemy/RedKoopa.prefab
@@ -44,6 +44,32 @@ PrefabInstance:
       propertyPath: 'NetworkGuid.RawGuidValue.Array.data[1]'
       value: 1233864249221731145
       objectReference: {fileID: 0}
+    - target: {fileID: 5481124906070657043, guid: 4f50cb5e806289d43bf820de1f1347bb,
+        type: 3}
+      propertyPath: respawnColor.a
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5481124906070657043, guid: 4f50cb5e806289d43bf820de1f1347bb,
+        type: 3}
+      propertyPath: respawnColor.b
+      value: 0.19339621
+      objectReference: {fileID: 0}
+    - target: {fileID: 5481124906070657043, guid: 4f50cb5e806289d43bf820de1f1347bb,
+        type: 3}
+      propertyPath: respawnColor.g
+      value: 0.19339621
+      objectReference: {fileID: 0}
+    - target: {fileID: 5481124906070657043, guid: 4f50cb5e806289d43bf820de1f1347bb,
+        type: 3}
+      propertyPath: respawnColor.r
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 5481124906070657043, guid: 4f50cb5e806289d43bf820de1f1347bb,
+        type: 3}
+      propertyPath: respawnParticle
+      value: 
+      objectReference: {fileID: 5191653714546004373, guid: cb33e5df66c9644458081c1ddef24e6c,
+        type: 3}
     - target: {fileID: 5521876106847805377, guid: 4f50cb5e806289d43bf820de1f1347bb,
         type: 3}
       propertyPath: _interpolationDataSource

--- a/Assets/QuantumUser/Resources/EntityPrototypes/Enemy/Spiny.prefab
+++ b/Assets/QuantumUser/Resources/EntityPrototypes/Enemy/Spiny.prefab
@@ -330,7 +330,7 @@ MonoBehaviour:
   rotation: {fileID: 7237572828892493257}
   respawnParticle: {fileID: 5191653714546004373, guid: cb33e5df66c9644458081c1ddef24e6c,
     type: 3}
-  respawnColor: {r: 1, g: 0.9799079, b: 0.2028302, a: 0}
+  respawnColor: {r: 1, g: 0.9799079, b: 0.2028302, a: 1}
   mirrorSprite: 1
   dontFlip: 1
 --- !u!82 &5072740182388110993

--- a/Assets/QuantumUser/Resources/EntityPrototypes/Enemy/Spiny.prefab
+++ b/Assets/QuantumUser/Resources/EntityPrototypes/Enemy/Spiny.prefab
@@ -328,6 +328,9 @@ MonoBehaviour:
   sfx: {fileID: 1632668266777924140}
   sRenderer: {fileID: 5045576353537437192}
   rotation: {fileID: 7237572828892493257}
+  respawnParticle: {fileID: 5191653714546004373, guid: cb33e5df66c9644458081c1ddef24e6c,
+    type: 3}
+  respawnColor: {r: 1, g: 0.9799079, b: 0.2028302, a: 0}
   mirrorSprite: 1
   dontFlip: 1
 --- !u!82 &5072740182388110993

--- a/Assets/QuantumUser/Simulation/Generated/Quantum.CodeGen.Core.cs
+++ b/Assets/QuantumUser/Simulation/Generated/Quantum.CodeGen.Core.cs
@@ -2071,15 +2071,15 @@ namespace Quantum {
   }
   [StructLayout(LayoutKind.Explicit)]
   public unsafe partial struct Enemy : Quantum.IComponent {
-    public const Int32 SIZE = 48;
+    public const Int32 SIZE = 56;
     public const Int32 ALIGNMENT = 8;
-    [FieldOffset(32)]
+    [FieldOffset(40)]
     public FPVector2 Spawnpoint;
     [FieldOffset(16)]
     public QBoolean IgnorePlayerWhenRespawning;
     [FieldOffset(8)]
     public QBoolean DisableRespawning;
-    [FieldOffset(28)]
+    [FieldOffset(32)]
     public QBoolean StayAtHomeWhenOffscreen;
     [FieldOffset(20)]
     [ExcludeFromPrototype()]
@@ -2090,6 +2090,9 @@ namespace Quantum {
     [FieldOffset(12)]
     [ExcludeFromPrototype()]
     public QBoolean FacingRight;
+    [FieldOffset(28)]
+    [ExcludeFromPrototype()]
+    public QBoolean LeftHome;
     [FieldOffset(4)]
     [ExcludeFromPrototype()]
     public Int32 RespawnTimer;
@@ -2106,6 +2109,7 @@ namespace Quantum {
         hash = hash * 31 + IsActive.GetHashCode();
         hash = hash * 31 + IsDead.GetHashCode();
         hash = hash * 31 + FacingRight.GetHashCode();
+        hash = hash * 31 + LeftHome.GetHashCode();
         hash = hash * 31 + RespawnTimer.GetHashCode();
         hash = hash * 31 + RespawnSparklesTimer.GetHashCode();
         return hash;
@@ -2120,6 +2124,7 @@ namespace Quantum {
         QBoolean.Serialize(&p->IgnorePlayerWhenRespawning, serializer);
         QBoolean.Serialize(&p->IsActive, serializer);
         QBoolean.Serialize(&p->IsDead, serializer);
+        QBoolean.Serialize(&p->LeftHome, serializer);
         QBoolean.Serialize(&p->StayAtHomeWhenOffscreen, serializer);
         FPVector2.Serialize(&p->Spawnpoint, serializer);
     }
@@ -3502,7 +3507,7 @@ namespace Quantum {
   public static unsafe partial class Constants {
     public const Int32 MaxStarSpawns = 64;
     public const Int32 EnemyHomeBoxWidth = 8;
-    public const Int32 EnemyHomeBoxBuffer = 10;
+    public const Int32 EnemyHomeBoxBuffer = 8;
     public const Int32 EnemyHomeBoxLeaveWidth = 3;
     public const Int32 MaxPlayers = 10;
     /// <summary>8.5</summary>

--- a/Assets/QuantumUser/Simulation/Generated/Quantum.CodeGen.Core.cs
+++ b/Assets/QuantumUser/Simulation/Generated/Quantum.CodeGen.Core.cs
@@ -3432,9 +3432,6 @@ namespace Quantum {
   public unsafe partial interface ISignalOnEnemyRespawnSparkles : ISignal {
     void OnEnemyRespawnSparkles(Frame f, EntityRef entity);
   }
-  public unsafe partial interface ISignalOnEnemyAfterDelayedRespawn : ISignal {
-    void OnEnemyAfterDelayedRespawn(Frame f, EntityRef entity);
-  }
   public unsafe partial interface ISignalOnEntityFreeze : ISignal {
     void OnEntityFreeze(Frame f, EntityRef entity, EntityRef iceBlock);
   }
@@ -3808,7 +3805,6 @@ namespace Quantum {
     private ISignalOnEnemyTurnaround[] _ISignalOnEnemyTurnaroundSystems;
     private ISignalOnEnemyReturnedHome[] _ISignalOnEnemyReturnedHomeSystems;
     private ISignalOnEnemyRespawnSparkles[] _ISignalOnEnemyRespawnSparklesSystems;
-    private ISignalOnEnemyAfterDelayedRespawn[] _ISignalOnEnemyAfterDelayedRespawnSystems;
     private ISignalOnEntityFreeze[] _ISignalOnEntityFreezeSystems;
     private ISignalOnLoadingComplete[] _ISignalOnLoadingCompleteSystems;
     private ISignalOnGameStarting[] _ISignalOnGameStartingSystems;
@@ -3856,7 +3852,6 @@ namespace Quantum {
       _ISignalOnEnemyTurnaroundSystems = BuildSignalsArray<ISignalOnEnemyTurnaround>();
       _ISignalOnEnemyReturnedHomeSystems = BuildSignalsArray<ISignalOnEnemyReturnedHome>();
       _ISignalOnEnemyRespawnSparklesSystems = BuildSignalsArray<ISignalOnEnemyRespawnSparkles>();
-      _ISignalOnEnemyAfterDelayedRespawnSystems = BuildSignalsArray<ISignalOnEnemyAfterDelayedRespawn>();
       _ISignalOnEntityFreezeSystems = BuildSignalsArray<ISignalOnEntityFreeze>();
       _ISignalOnLoadingCompleteSystems = BuildSignalsArray<ISignalOnLoadingComplete>();
       _ISignalOnGameStartingSystems = BuildSignalsArray<ISignalOnGameStarting>();
@@ -4139,15 +4134,6 @@ namespace Quantum {
           var s = array[i];
           if (_f.SystemIsEnabledInHierarchy((SystemBase)s)) {
             s.OnEnemyRespawnSparkles(_f, entity);
-          }
-        }
-      }
-      public void OnEnemyAfterDelayedRespawn(EntityRef entity) {
-        var array = _f._ISignalOnEnemyAfterDelayedRespawnSystems;
-        for (Int32 i = 0; i < array.Length; ++i) {
-          var s = array[i];
-          if (_f.SystemIsEnabledInHierarchy((SystemBase)s)) {
-            s.OnEnemyAfterDelayedRespawn(_f, entity);
           }
         }
       }

--- a/Assets/QuantumUser/Simulation/Generated/Quantum.CodeGen.Core.cs
+++ b/Assets/QuantumUser/Simulation/Generated/Quantum.CodeGen.Core.cs
@@ -2071,25 +2071,31 @@ namespace Quantum {
   }
   [StructLayout(LayoutKind.Explicit)]
   public unsafe partial struct Enemy : Quantum.IComponent {
-    public const Int32 SIZE = 40;
+    public const Int32 SIZE = 48;
     public const Int32 ALIGNMENT = 8;
-    [FieldOffset(24)]
+    [FieldOffset(32)]
     public FPVector2 Spawnpoint;
-    [FieldOffset(8)]
+    [FieldOffset(16)]
     public QBoolean IgnorePlayerWhenRespawning;
-    [FieldOffset(0)]
+    [FieldOffset(8)]
     public QBoolean DisableRespawning;
-    [FieldOffset(20)]
+    [FieldOffset(28)]
     public QBoolean StayAtHomeWhenOffscreen;
-    [FieldOffset(12)]
+    [FieldOffset(20)]
     [ExcludeFromPrototype()]
     public QBoolean IsActive;
-    [FieldOffset(16)]
+    [FieldOffset(24)]
     [ExcludeFromPrototype()]
     public QBoolean IsDead;
-    [FieldOffset(4)]
+    [FieldOffset(12)]
     [ExcludeFromPrototype()]
     public QBoolean FacingRight;
+    [FieldOffset(4)]
+    [ExcludeFromPrototype()]
+    public Int32 RespawnTimer;
+    [FieldOffset(0)]
+    [ExcludeFromPrototype()]
+    public Int32 RespawnSparklesTimer;
     public override readonly Int32 GetHashCode() {
       unchecked { 
         var hash = 11071;
@@ -2100,11 +2106,15 @@ namespace Quantum {
         hash = hash * 31 + IsActive.GetHashCode();
         hash = hash * 31 + IsDead.GetHashCode();
         hash = hash * 31 + FacingRight.GetHashCode();
+        hash = hash * 31 + RespawnTimer.GetHashCode();
+        hash = hash * 31 + RespawnSparklesTimer.GetHashCode();
         return hash;
       }
     }
     public static void Serialize(void* ptr, FrameSerializer serializer) {
         var p = (Enemy*)ptr;
+        serializer.Stream.Serialize(&p->RespawnSparklesTimer);
+        serializer.Stream.Serialize(&p->RespawnTimer);
         QBoolean.Serialize(&p->DisableRespawning, serializer);
         QBoolean.Serialize(&p->FacingRight, serializer);
         QBoolean.Serialize(&p->IgnorePlayerWhenRespawning, serializer);
@@ -3414,6 +3424,12 @@ namespace Quantum {
   public unsafe partial interface ISignalOnEnemyReturnedHome : ISignal {
     void OnEnemyReturnedHome(Frame f, EntityRef entity);
   }
+  public unsafe partial interface ISignalOnEnemyRespawnSparkles : ISignal {
+    void OnEnemyRespawnSparkles(Frame f, EntityRef entity);
+  }
+  public unsafe partial interface ISignalOnEnemyAfterDelayedRespawn : ISignal {
+    void OnEnemyAfterDelayedRespawn(Frame f, EntityRef entity);
+  }
   public unsafe partial interface ISignalOnEntityFreeze : ISignal {
     void OnEntityFreeze(Frame f, EntityRef entity, EntityRef iceBlock);
   }
@@ -3784,6 +3800,8 @@ namespace Quantum {
     private ISignalOnEnemyKilledByStageReset[] _ISignalOnEnemyKilledByStageResetSystems;
     private ISignalOnEnemyTurnaround[] _ISignalOnEnemyTurnaroundSystems;
     private ISignalOnEnemyReturnedHome[] _ISignalOnEnemyReturnedHomeSystems;
+    private ISignalOnEnemyRespawnSparkles[] _ISignalOnEnemyRespawnSparklesSystems;
+    private ISignalOnEnemyAfterDelayedRespawn[] _ISignalOnEnemyAfterDelayedRespawnSystems;
     private ISignalOnEntityFreeze[] _ISignalOnEntityFreezeSystems;
     private ISignalOnLoadingComplete[] _ISignalOnLoadingCompleteSystems;
     private ISignalOnGameStarting[] _ISignalOnGameStartingSystems;
@@ -3830,6 +3848,8 @@ namespace Quantum {
       _ISignalOnEnemyKilledByStageResetSystems = BuildSignalsArray<ISignalOnEnemyKilledByStageReset>();
       _ISignalOnEnemyTurnaroundSystems = BuildSignalsArray<ISignalOnEnemyTurnaround>();
       _ISignalOnEnemyReturnedHomeSystems = BuildSignalsArray<ISignalOnEnemyReturnedHome>();
+      _ISignalOnEnemyRespawnSparklesSystems = BuildSignalsArray<ISignalOnEnemyRespawnSparkles>();
+      _ISignalOnEnemyAfterDelayedRespawnSystems = BuildSignalsArray<ISignalOnEnemyAfterDelayedRespawn>();
       _ISignalOnEntityFreezeSystems = BuildSignalsArray<ISignalOnEntityFreeze>();
       _ISignalOnLoadingCompleteSystems = BuildSignalsArray<ISignalOnLoadingComplete>();
       _ISignalOnGameStartingSystems = BuildSignalsArray<ISignalOnGameStarting>();
@@ -4103,6 +4123,24 @@ namespace Quantum {
           var s = array[i];
           if (_f.SystemIsEnabledInHierarchy((SystemBase)s)) {
             s.OnEnemyReturnedHome(_f, entity);
+          }
+        }
+      }
+      public void OnEnemyRespawnSparkles(EntityRef entity) {
+        var array = _f._ISignalOnEnemyRespawnSparklesSystems;
+        for (Int32 i = 0; i < array.Length; ++i) {
+          var s = array[i];
+          if (_f.SystemIsEnabledInHierarchy((SystemBase)s)) {
+            s.OnEnemyRespawnSparkles(_f, entity);
+          }
+        }
+      }
+      public void OnEnemyAfterDelayedRespawn(EntityRef entity) {
+        var array = _f._ISignalOnEnemyAfterDelayedRespawnSystems;
+        for (Int32 i = 0; i < array.Length; ++i) {
+          var s = array[i];
+          if (_f.SystemIsEnabledInHierarchy((SystemBase)s)) {
+            s.OnEnemyAfterDelayedRespawn(_f, entity);
           }
         }
       }

--- a/Assets/QuantumUser/Simulation/Generated/Quantum.CodeGen.Core.cs
+++ b/Assets/QuantumUser/Simulation/Generated/Quantum.CodeGen.Core.cs
@@ -3503,7 +3503,7 @@ namespace Quantum {
   }
   public static unsafe partial class Constants {
     public const Int32 MaxStarSpawns = 64;
-    public const Int32 EnemyHomeBoxWidth = 8;
+    public const Int32 EnemyMaxDistFromMario = 8;
     public const Int32 EnemyHomeBoxBuffer = 8;
     public const Int32 EnemyHomeBoxLeaveWidth = 3;
     public const Int32 MaxPlayers = 10;

--- a/Assets/QuantumUser/Simulation/Generated/Quantum.CodeGen.Core.cs
+++ b/Assets/QuantumUser/Simulation/Generated/Quantum.CodeGen.Core.cs
@@ -3501,7 +3501,9 @@ namespace Quantum {
   }
   public static unsafe partial class Constants {
     public const Int32 MaxStarSpawns = 64;
-    public const Int32 EnemyHomeRadius = 12;
+    public const Int32 EnemyHomeBoxWidth = 8;
+    public const Int32 EnemyHomeBoxBuffer = 10;
+    public const Int32 EnemyHomeBoxLeaveWidth = 3;
     public const Int32 MaxPlayers = 10;
     /// <summary>8.5</summary>
     public static FP _8_50 {

--- a/Assets/QuantumUser/Simulation/Generated/Quantum.CodeGen.Events.cs
+++ b/Assets/QuantumUser/Simulation/Generated/Quantum.CodeGen.Events.cs
@@ -52,7 +52,7 @@ namespace Quantum {
   public unsafe partial class Frame {
     public unsafe partial struct FrameEvents {
       static partial void GetEventTypeCountCodeGen(ref Int32 eventCount) {
-        eventCount = 87;
+        eventCount = 88;
       }
       static partial void GetParentEventIDCodeGen(Int32 eventID, ref Int32 parentEventID) {
         switch (eventID) {
@@ -83,6 +83,7 @@ namespace Quantum {
           case EventPlayComboSound.ID: result = typeof(EventPlayComboSound); return;
           case EventPlayBumpSound.ID: result = typeof(EventPlayBumpSound); return;
           case EventEnemyKicked.ID: result = typeof(EventEnemyKicked); return;
+          case EventEnemySufferedOffscreen.ID: result = typeof(EventEnemySufferedOffscreen); return;
           case EventEnemyRespawnSparkles.ID: result = typeof(EventEnemyRespawnSparkles); return;
           case EventEnemyAfterDelayedRespawn.ID: result = typeof(EventEnemyAfterDelayedRespawn); return;
           case EventGameStateChanged.ID: result = typeof(EventGameStateChanged); return;
@@ -307,6 +308,13 @@ namespace Quantum {
         var ev = _f.Context.AcquireEvent<EventEnemyKicked>(EventEnemyKicked.ID);
         ev.Entity = Entity;
         ev.Groundpounded = Groundpounded;
+        _f.AddEvent(ev);
+        return ev;
+      }
+      public EventEnemySufferedOffscreen EnemySufferedOffscreen(EntityRef Entity, FPVector2 Position) {
+        var ev = _f.Context.AcquireEvent<EventEnemySufferedOffscreen>(EventEnemySufferedOffscreen.ID);
+        ev.Entity = Entity;
+        ev.Position = Position;
         _f.AddEvent(ev);
         return ev;
       }
@@ -1353,13 +1361,14 @@ namespace Quantum {
       }
     }
   }
-  public unsafe partial class EventEnemyRespawnSparkles : EventBase {
+  public unsafe partial class EventEnemySufferedOffscreen : EventBase {
     public new const Int32 ID = 23;
     public EntityRef Entity;
-    protected EventEnemyRespawnSparkles(Int32 id, EventFlags flags) : 
+    public FPVector2 Position;
+    protected EventEnemySufferedOffscreen(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventEnemyRespawnSparkles() : 
+    public EventEnemySufferedOffscreen() : 
         base(23, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -1378,13 +1387,13 @@ namespace Quantum {
       }
     }
   }
-  public unsafe partial class EventEnemyAfterDelayedRespawn : EventBase {
+  public unsafe partial class EventEnemyRespawnSparkles : EventBase {
     public new const Int32 ID = 24;
     public EntityRef Entity;
-    protected EventEnemyAfterDelayedRespawn(Int32 id, EventFlags flags) : 
+    protected EventEnemyRespawnSparkles(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventEnemyAfterDelayedRespawn() : 
+    public EventEnemyRespawnSparkles() : 
         base(24, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -1403,14 +1412,14 @@ namespace Quantum {
       }
     }
   }
-  public unsafe partial class EventGameStateChanged : EventBase {
+  public unsafe partial class EventEnemyAfterDelayedRespawn : EventBase {
     public new const Int32 ID = 25;
-    public GameState NewState;
-    protected EventGameStateChanged(Int32 id, EventFlags flags) : 
+    public EntityRef Entity;
+    protected EventEnemyAfterDelayedRespawn(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventGameStateChanged() : 
-        base(25, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
+    public EventEnemyAfterDelayedRespawn() : 
+        base(25, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
       get {
@@ -1423,18 +1432,18 @@ namespace Quantum {
     public override Int32 GetHashCode() {
       unchecked {
         var hash = 157;
-        hash = hash * 31 + NewState.GetHashCode();
+        hash = hash * 31 + Entity.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventPlayerAdded : EventBase {
+  public unsafe partial class EventGameStateChanged : EventBase {
     public new const Int32 ID = 26;
-    public PlayerRef Player;
-    protected EventPlayerAdded(Int32 id, EventFlags flags) : 
+    public GameState NewState;
+    protected EventGameStateChanged(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventPlayerAdded() : 
+    public EventGameStateChanged() : 
         base(26, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
     }
     public new QuantumGame Game {
@@ -1448,18 +1457,18 @@ namespace Quantum {
     public override Int32 GetHashCode() {
       unchecked {
         var hash = 163;
-        hash = hash * 31 + Player.GetHashCode();
+        hash = hash * 31 + NewState.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventPlayerRemoved : EventBase {
+  public unsafe partial class EventPlayerAdded : EventBase {
     public new const Int32 ID = 27;
     public PlayerRef Player;
-    protected EventPlayerRemoved(Int32 id, EventFlags flags) : 
+    protected EventPlayerAdded(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventPlayerRemoved() : 
+    public EventPlayerAdded() : 
         base(27, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
     }
     public new QuantumGame Game {
@@ -1478,14 +1487,14 @@ namespace Quantum {
       }
     }
   }
-  public unsafe partial class EventPlayerDataChanged : EventBase {
+  public unsafe partial class EventPlayerRemoved : EventBase {
     public new const Int32 ID = 28;
     public PlayerRef Player;
-    protected EventPlayerDataChanged(Int32 id, EventFlags flags) : 
+    protected EventPlayerRemoved(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventPlayerDataChanged() : 
-        base(28, EventFlags.Server|EventFlags.Client) {
+    public EventPlayerRemoved() : 
+        base(28, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
     }
     public new QuantumGame Game {
       get {
@@ -1503,14 +1512,14 @@ namespace Quantum {
       }
     }
   }
-  public unsafe partial class EventStartingCountdownChanged : EventBase {
+  public unsafe partial class EventPlayerDataChanged : EventBase {
     public new const Int32 ID = 29;
-    public QBoolean IsGameStarting;
-    protected EventStartingCountdownChanged(Int32 id, EventFlags flags) : 
+    public PlayerRef Player;
+    protected EventPlayerDataChanged(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventStartingCountdownChanged() : 
-        base(29, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
+    public EventPlayerDataChanged() : 
+        base(29, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
       get {
@@ -1523,19 +1532,19 @@ namespace Quantum {
     public override Int32 GetHashCode() {
       unchecked {
         var hash = 179;
-        hash = hash * 31 + IsGameStarting.GetHashCode();
+        hash = hash * 31 + Player.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventCountdownTick : EventBase {
+  public unsafe partial class EventStartingCountdownChanged : EventBase {
     public new const Int32 ID = 30;
-    public Int32 SecondsRemaining;
-    protected EventCountdownTick(Int32 id, EventFlags flags) : 
+    public QBoolean IsGameStarting;
+    protected EventStartingCountdownChanged(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventCountdownTick() : 
-        base(30, EventFlags.Server|EventFlags.Client) {
+    public EventStartingCountdownChanged() : 
+        base(30, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
     }
     public new QuantumGame Game {
       get {
@@ -1548,19 +1557,19 @@ namespace Quantum {
     public override Int32 GetHashCode() {
       unchecked {
         var hash = 181;
-        hash = hash * 31 + SecondsRemaining.GetHashCode();
+        hash = hash * 31 + IsGameStarting.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventHostChanged : EventBase {
+  public unsafe partial class EventCountdownTick : EventBase {
     public new const Int32 ID = 31;
-    public PlayerRef NewHost;
-    protected EventHostChanged(Int32 id, EventFlags flags) : 
+    public Int32 SecondsRemaining;
+    protected EventCountdownTick(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventHostChanged() : 
-        base(31, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
+    public EventCountdownTick() : 
+        base(31, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
       get {
@@ -1573,19 +1582,18 @@ namespace Quantum {
     public override Int32 GetHashCode() {
       unchecked {
         var hash = 191;
-        hash = hash * 31 + NewHost.GetHashCode();
+        hash = hash * 31 + SecondsRemaining.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventRulesChanged : EventBase {
+  public unsafe partial class EventHostChanged : EventBase {
     public new const Int32 ID = 32;
-    public QBoolean GamemodeChanged;
-    public QBoolean MapChanged;
-    protected EventRulesChanged(Int32 id, EventFlags flags) : 
+    public PlayerRef NewHost;
+    protected EventHostChanged(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventRulesChanged() : 
+    public EventHostChanged() : 
         base(32, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
     }
     public new QuantumGame Game {
@@ -1599,18 +1607,19 @@ namespace Quantum {
     public override Int32 GetHashCode() {
       unchecked {
         var hash = 193;
-        hash = hash * 31 + GamemodeChanged.GetHashCode();
-        hash = hash * 31 + MapChanged.GetHashCode();
+        hash = hash * 31 + NewHost.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventHostCloseRulesPanel : EventBase {
+  public unsafe partial class EventRulesChanged : EventBase {
     public new const Int32 ID = 33;
-    protected EventHostCloseRulesPanel(Int32 id, EventFlags flags) : 
+    public QBoolean GamemodeChanged;
+    public QBoolean MapChanged;
+    protected EventRulesChanged(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventHostCloseRulesPanel() : 
+    public EventRulesChanged() : 
         base(33, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
     }
     public new QuantumGame Game {
@@ -1624,17 +1633,18 @@ namespace Quantum {
     public override Int32 GetHashCode() {
       unchecked {
         var hash = 197;
+        hash = hash * 31 + GamemodeChanged.GetHashCode();
+        hash = hash * 31 + MapChanged.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventPlayerLoaded : EventBase {
+  public unsafe partial class EventHostCloseRulesPanel : EventBase {
     public new const Int32 ID = 34;
-    public PlayerRef Player;
-    protected EventPlayerLoaded(Int32 id, EventFlags flags) : 
+    protected EventHostCloseRulesPanel(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventPlayerLoaded() : 
+    public EventHostCloseRulesPanel() : 
         base(34, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
     }
     public new QuantumGame Game {
@@ -1648,17 +1658,17 @@ namespace Quantum {
     public override Int32 GetHashCode() {
       unchecked {
         var hash = 199;
-        hash = hash * 31 + Player.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventRecordingStarted : EventBase {
+  public unsafe partial class EventPlayerLoaded : EventBase {
     public new const Int32 ID = 35;
-    protected EventRecordingStarted(Int32 id, EventFlags flags) : 
+    public PlayerRef Player;
+    protected EventPlayerLoaded(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventRecordingStarted() : 
+    public EventPlayerLoaded() : 
         base(35, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
     }
     public new QuantumGame Game {
@@ -1672,16 +1682,17 @@ namespace Quantum {
     public override Int32 GetHashCode() {
       unchecked {
         var hash = 211;
+        hash = hash * 31 + Player.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventGameStarted : EventBase {
+  public unsafe partial class EventRecordingStarted : EventBase {
     public new const Int32 ID = 36;
-    protected EventGameStarted(Int32 id, EventFlags flags) : 
+    protected EventRecordingStarted(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventGameStarted() : 
+    public EventRecordingStarted() : 
         base(36, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
     }
     public new QuantumGame Game {
@@ -1699,15 +1710,12 @@ namespace Quantum {
       }
     }
   }
-  public unsafe partial class EventGameEnded : EventBase {
+  public unsafe partial class EventGameStarted : EventBase {
     public new const Int32 ID = 37;
-    public QBoolean EndedByHost;
-    public Int32 WinningTeam;
-    public QBoolean HasWinner;
-    protected EventGameEnded(Int32 id, EventFlags flags) : 
+    protected EventGameStarted(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventGameEnded() : 
+    public EventGameStarted() : 
         base(37, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
     }
     public new QuantumGame Game {
@@ -1721,20 +1729,20 @@ namespace Quantum {
     public override Int32 GetHashCode() {
       unchecked {
         var hash = 227;
-        hash = hash * 31 + EndedByHost.GetHashCode();
-        hash = hash * 31 + WinningTeam.GetHashCode();
-        hash = hash * 31 + HasWinner.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventStartGameEndFade : EventBase {
+  public unsafe partial class EventGameEnded : EventBase {
     public new const Int32 ID = 38;
-    protected EventStartGameEndFade(Int32 id, EventFlags flags) : 
+    public QBoolean EndedByHost;
+    public Int32 WinningTeam;
+    public QBoolean HasWinner;
+    protected EventGameEnded(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventStartGameEndFade() : 
-        base(38, EventFlags.Server|EventFlags.Client) {
+    public EventGameEnded() : 
+        base(38, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
     }
     public new QuantumGame Game {
       get {
@@ -1747,17 +1755,20 @@ namespace Quantum {
     public override Int32 GetHashCode() {
       unchecked {
         var hash = 229;
+        hash = hash * 31 + EndedByHost.GetHashCode();
+        hash = hash * 31 + WinningTeam.GetHashCode();
+        hash = hash * 31 + HasWinner.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventStageAutoRefresh : EventBase {
+  public unsafe partial class EventStartGameEndFade : EventBase {
     public new const Int32 ID = 39;
-    protected EventStageAutoRefresh(Int32 id, EventFlags flags) : 
+    protected EventStartGameEndFade(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventStageAutoRefresh() : 
-        base(39, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
+    public EventStartGameEndFade() : 
+        base(39, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
       get {
@@ -1774,15 +1785,13 @@ namespace Quantum {
       }
     }
   }
-  public unsafe partial class EventMarioPlayerPickedUpGoldBlock : EventBase {
+  public unsafe partial class EventStageAutoRefresh : EventBase {
     public new const Int32 ID = 40;
-    public EntityRef Entity;
-    public EntityRef GoldBlock;
-    protected EventMarioPlayerPickedUpGoldBlock(Int32 id, EventFlags flags) : 
+    protected EventStageAutoRefresh(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerPickedUpGoldBlock() : 
-        base(40, EventFlags.Server|EventFlags.Client) {
+    public EventStageAutoRefresh() : 
+        base(40, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
     }
     public new QuantumGame Game {
       get {
@@ -1795,19 +1804,18 @@ namespace Quantum {
     public override Int32 GetHashCode() {
       unchecked {
         var hash = 239;
-        hash = hash * 31 + Entity.GetHashCode();
-        hash = hash * 31 + GoldBlock.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventGoldBlockGeneratedObjectiveCoin : EventBase {
+  public unsafe partial class EventMarioPlayerPickedUpGoldBlock : EventBase {
     public new const Int32 ID = 41;
+    public EntityRef Entity;
     public EntityRef GoldBlock;
-    protected EventGoldBlockGeneratedObjectiveCoin(Int32 id, EventFlags flags) : 
+    protected EventMarioPlayerPickedUpGoldBlock(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventGoldBlockGeneratedObjectiveCoin() : 
+    public EventMarioPlayerPickedUpGoldBlock() : 
         base(41, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -1821,18 +1829,19 @@ namespace Quantum {
     public override Int32 GetHashCode() {
       unchecked {
         var hash = 241;
+        hash = hash * 31 + Entity.GetHashCode();
         hash = hash * 31 + GoldBlock.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventGoldBlockRanOutOfCoins : EventBase {
+  public unsafe partial class EventGoldBlockGeneratedObjectiveCoin : EventBase {
     public new const Int32 ID = 42;
     public EntityRef GoldBlock;
-    protected EventGoldBlockRanOutOfCoins(Int32 id, EventFlags flags) : 
+    protected EventGoldBlockGeneratedObjectiveCoin(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventGoldBlockRanOutOfCoins() : 
+    public EventGoldBlockGeneratedObjectiveCoin() : 
         base(42, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -1851,13 +1860,13 @@ namespace Quantum {
       }
     }
   }
-  public unsafe partial class EventGoldBlockBrokenByMega : EventBase {
+  public unsafe partial class EventGoldBlockRanOutOfCoins : EventBase {
     public new const Int32 ID = 43;
     public EntityRef GoldBlock;
-    protected EventGoldBlockBrokenByMega(Int32 id, EventFlags flags) : 
+    protected EventGoldBlockRanOutOfCoins(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventGoldBlockBrokenByMega() : 
+    public EventGoldBlockRanOutOfCoins() : 
         base(43, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -1876,14 +1885,14 @@ namespace Quantum {
       }
     }
   }
-  public unsafe partial class EventGoldBlockLostViaDamage : EventBase {
+  public unsafe partial class EventGoldBlockBrokenByMega : EventBase {
     public new const Int32 ID = 44;
     public EntityRef GoldBlock;
-    protected EventGoldBlockLostViaDamage(Int32 id, EventFlags flags) : 
+    protected EventGoldBlockBrokenByMega(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventGoldBlockLostViaDamage() : 
-        base(44, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
+    public EventGoldBlockBrokenByMega() : 
+        base(44, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
       get {
@@ -1901,15 +1910,14 @@ namespace Quantum {
       }
     }
   }
-  public unsafe partial class EventIceBlockSinking : EventBase {
+  public unsafe partial class EventGoldBlockLostViaDamage : EventBase {
     public new const Int32 ID = 45;
-    public EntityRef Entity;
-    public LiquidType LiquidType;
-    protected EventIceBlockSinking(Int32 id, EventFlags flags) : 
+    public EntityRef GoldBlock;
+    protected EventGoldBlockLostViaDamage(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventIceBlockSinking() : 
-        base(45, EventFlags.Server|EventFlags.Client) {
+    public EventGoldBlockLostViaDamage() : 
+        base(45, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
     }
     public new QuantumGame Game {
       get {
@@ -1922,23 +1930,19 @@ namespace Quantum {
     public override Int32 GetHashCode() {
       unchecked {
         var hash = 269;
-        hash = hash * 31 + Entity.GetHashCode();
-        hash = hash * 31 + LiquidType.GetHashCode();
+        hash = hash * 31 + GoldBlock.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventLiquidSplashed : EventBase {
+  public unsafe partial class EventIceBlockSinking : EventBase {
     public new const Int32 ID = 46;
     public EntityRef Entity;
-    public EntityRef Splasher;
-    public FP Force;
-    public FPVector2 Position;
-    public QBoolean Exit;
-    protected EventLiquidSplashed(Int32 id, EventFlags flags) : 
+    public LiquidType LiquidType;
+    protected EventIceBlockSinking(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventLiquidSplashed() : 
+    public EventIceBlockSinking() : 
         base(46, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -1953,20 +1957,22 @@ namespace Quantum {
       unchecked {
         var hash = 271;
         hash = hash * 31 + Entity.GetHashCode();
-        hash = hash * 31 + Splasher.GetHashCode();
-        hash = hash * 31 + Exit.GetHashCode();
+        hash = hash * 31 + LiquidType.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventMarioBrosPlatformBumped : EventBase {
+  public unsafe partial class EventLiquidSplashed : EventBase {
     public new const Int32 ID = 47;
     public EntityRef Entity;
+    public EntityRef Splasher;
+    public FP Force;
     public FPVector2 Position;
-    protected EventMarioBrosPlatformBumped(Int32 id, EventFlags flags) : 
+    public QBoolean Exit;
+    protected EventLiquidSplashed(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioBrosPlatformBumped() : 
+    public EventLiquidSplashed() : 
         base(47, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -1981,21 +1987,20 @@ namespace Quantum {
       unchecked {
         var hash = 277;
         hash = hash * 31 + Entity.GetHashCode();
+        hash = hash * 31 + Splasher.GetHashCode();
+        hash = hash * 31 + Exit.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventMarioPlayerJumped : EventBase {
+  public unsafe partial class EventMarioBrosPlatformBumped : EventBase {
     public new const Int32 ID = 48;
     public EntityRef Entity;
-    public PowerupState PowerupState;
-    public JumpState JumpState;
-    public QBoolean WasBounce;
-    public QBoolean IsUnderwater;
-    protected EventMarioPlayerJumped(Int32 id, EventFlags flags) : 
+    public FPVector2 Position;
+    protected EventMarioBrosPlatformBumped(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerJumped() : 
+    public EventMarioBrosPlatformBumped() : 
         base(48, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -2014,13 +2019,17 @@ namespace Quantum {
       }
     }
   }
-  public unsafe partial class EventMarioPlayerGroundpoundStarted : EventBase {
+  public unsafe partial class EventMarioPlayerJumped : EventBase {
     public new const Int32 ID = 49;
     public EntityRef Entity;
-    protected EventMarioPlayerGroundpoundStarted(Int32 id, EventFlags flags) : 
+    public PowerupState PowerupState;
+    public JumpState JumpState;
+    public QBoolean WasBounce;
+    public QBoolean IsUnderwater;
+    protected EventMarioPlayerJumped(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerGroundpoundStarted() : 
+    public EventMarioPlayerJumped() : 
         base(49, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -2039,14 +2048,13 @@ namespace Quantum {
       }
     }
   }
-  public unsafe partial class EventMarioPlayerGroundpounded : EventBase {
+  public unsafe partial class EventMarioPlayerGroundpoundStarted : EventBase {
     public new const Int32 ID = 50;
     public EntityRef Entity;
-    public PowerupState PowerupState;
-    protected EventMarioPlayerGroundpounded(Int32 id, EventFlags flags) : 
+    protected EventMarioPlayerGroundpoundStarted(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerGroundpounded() : 
+    public EventMarioPlayerGroundpoundStarted() : 
         base(50, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -2065,14 +2073,14 @@ namespace Quantum {
       }
     }
   }
-  public unsafe partial class EventMarioPlayerCrouched : EventBase {
+  public unsafe partial class EventMarioPlayerGroundpounded : EventBase {
     public new const Int32 ID = 51;
     public EntityRef Entity;
     public PowerupState PowerupState;
-    protected EventMarioPlayerCrouched(Int32 id, EventFlags flags) : 
+    protected EventMarioPlayerGroundpounded(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerCrouched() : 
+    public EventMarioPlayerGroundpounded() : 
         base(51, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -2091,16 +2099,15 @@ namespace Quantum {
       }
     }
   }
-  public unsafe partial class EventMarioPlayerCollectedPowerup : EventBase {
+  public unsafe partial class EventMarioPlayerCrouched : EventBase {
     public new const Int32 ID = 52;
     public EntityRef Entity;
-    public PowerupReserveResult Result;
-    public PowerupAsset Scriptable;
-    protected EventMarioPlayerCollectedPowerup(Int32 id, EventFlags flags) : 
+    public PowerupState PowerupState;
+    protected EventMarioPlayerCrouched(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerCollectedPowerup() : 
-        base(52, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
+    public EventMarioPlayerCrouched() : 
+        base(52, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
       get {
@@ -2118,15 +2125,16 @@ namespace Quantum {
       }
     }
   }
-  public unsafe partial class EventMarioPlayerUsedReserveItem : EventBase {
+  public unsafe partial class EventMarioPlayerCollectedPowerup : EventBase {
     public new const Int32 ID = 53;
     public EntityRef Entity;
-    public QBoolean Success;
-    protected EventMarioPlayerUsedReserveItem(Int32 id, EventFlags flags) : 
+    public PowerupReserveResult Result;
+    public PowerupAsset Scriptable;
+    protected EventMarioPlayerCollectedPowerup(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerUsedReserveItem() : 
-        base(53, EventFlags.Server|EventFlags.Client) {
+    public EventMarioPlayerCollectedPowerup() : 
+        base(53, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
     }
     public new QuantumGame Game {
       get {
@@ -2144,16 +2152,14 @@ namespace Quantum {
       }
     }
   }
-  public unsafe partial class EventMarioPlayerWalljumped : EventBase {
+  public unsafe partial class EventMarioPlayerUsedReserveItem : EventBase {
     public new const Int32 ID = 54;
     public EntityRef Entity;
-    public FPVector2 Position;
-    public QBoolean WasOnRightWall;
-    public FPVector2 HitboxExtents;
-    protected EventMarioPlayerWalljumped(Int32 id, EventFlags flags) : 
+    public QBoolean Success;
+    protected EventMarioPlayerUsedReserveItem(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerWalljumped() : 
+    public EventMarioPlayerUsedReserveItem() : 
         base(54, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -2172,14 +2178,16 @@ namespace Quantum {
       }
     }
   }
-  public unsafe partial class EventMarioPlayerShotProjectile : EventBase {
+  public unsafe partial class EventMarioPlayerWalljumped : EventBase {
     public new const Int32 ID = 55;
     public EntityRef Entity;
-    public Projectile Projectile;
-    protected EventMarioPlayerShotProjectile(Int32 id, EventFlags flags) : 
+    public FPVector2 Position;
+    public QBoolean WasOnRightWall;
+    public FPVector2 HitboxExtents;
+    protected EventMarioPlayerWalljumped(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerShotProjectile() : 
+    public EventMarioPlayerWalljumped() : 
         base(55, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -2198,13 +2206,14 @@ namespace Quantum {
       }
     }
   }
-  public unsafe partial class EventMarioPlayerUsedPropeller : EventBase {
+  public unsafe partial class EventMarioPlayerShotProjectile : EventBase {
     public new const Int32 ID = 56;
     public EntityRef Entity;
-    protected EventMarioPlayerUsedPropeller(Int32 id, EventFlags flags) : 
+    public Projectile Projectile;
+    protected EventMarioPlayerShotProjectile(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerUsedPropeller() : 
+    public EventMarioPlayerShotProjectile() : 
         base(56, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -2223,13 +2232,13 @@ namespace Quantum {
       }
     }
   }
-  public unsafe partial class EventMarioPlayerPropellerSpin : EventBase {
+  public unsafe partial class EventMarioPlayerUsedPropeller : EventBase {
     public new const Int32 ID = 57;
     public EntityRef Entity;
-    protected EventMarioPlayerPropellerSpin(Int32 id, EventFlags flags) : 
+    protected EventMarioPlayerUsedPropeller(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerPropellerSpin() : 
+    public EventMarioPlayerUsedPropeller() : 
         base(57, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -2248,15 +2257,14 @@ namespace Quantum {
       }
     }
   }
-  public unsafe partial class EventMarioPlayerDied : EventBase {
+  public unsafe partial class EventMarioPlayerPropellerSpin : EventBase {
     public new const Int32 ID = 58;
     public EntityRef Entity;
-    public QBoolean IsLava;
-    protected EventMarioPlayerDied(Int32 id, EventFlags flags) : 
+    protected EventMarioPlayerPropellerSpin(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerDied() : 
-        base(58, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
+    public EventMarioPlayerPropellerSpin() : 
+        base(58, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
       get {
@@ -2270,20 +2278,19 @@ namespace Quantum {
       unchecked {
         var hash = 349;
         hash = hash * 31 + Entity.GetHashCode();
-        hash = hash * 31 + IsLava.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventMarioPlayerDeathUp : EventBase {
+  public unsafe partial class EventMarioPlayerDied : EventBase {
     public new const Int32 ID = 59;
     public EntityRef Entity;
-    public QBoolean FireDeath;
-    protected EventMarioPlayerDeathUp(Int32 id, EventFlags flags) : 
+    public QBoolean IsLava;
+    protected EventMarioPlayerDied(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerDeathUp() : 
-        base(59, EventFlags.Server|EventFlags.Client) {
+    public EventMarioPlayerDied() : 
+        base(59, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
     }
     public new QuantumGame Game {
       get {
@@ -2297,19 +2304,20 @@ namespace Quantum {
       unchecked {
         var hash = 353;
         hash = hash * 31 + Entity.GetHashCode();
-        hash = hash * 31 + FireDeath.GetHashCode();
+        hash = hash * 31 + IsLava.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventMarioPlayerTookDamage : EventBase {
+  public unsafe partial class EventMarioPlayerDeathUp : EventBase {
     public new const Int32 ID = 60;
     public EntityRef Entity;
-    protected EventMarioPlayerTookDamage(Int32 id, EventFlags flags) : 
+    public QBoolean FireDeath;
+    protected EventMarioPlayerDeathUp(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerTookDamage() : 
-        base(60, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
+    public EventMarioPlayerDeathUp() : 
+        base(60, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
       get {
@@ -2323,19 +2331,19 @@ namespace Quantum {
       unchecked {
         var hash = 359;
         hash = hash * 31 + Entity.GetHashCode();
+        hash = hash * 31 + FireDeath.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventMarioPlayerPreRespawned : EventBase {
+  public unsafe partial class EventMarioPlayerTookDamage : EventBase {
     public new const Int32 ID = 61;
     public EntityRef Entity;
-    public FPVector2 Spawnpoint;
-    protected EventMarioPlayerPreRespawned(Int32 id, EventFlags flags) : 
+    protected EventMarioPlayerTookDamage(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerPreRespawned() : 
-        base(61, EventFlags.Server|EventFlags.Client) {
+    public EventMarioPlayerTookDamage() : 
+        base(61, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
     }
     public new QuantumGame Game {
       get {
@@ -2353,13 +2361,14 @@ namespace Quantum {
       }
     }
   }
-  public unsafe partial class EventMarioPlayerRespawned : EventBase {
+  public unsafe partial class EventMarioPlayerPreRespawned : EventBase {
     public new const Int32 ID = 62;
     public EntityRef Entity;
-    protected EventMarioPlayerRespawned(Int32 id, EventFlags flags) : 
+    public FPVector2 Spawnpoint;
+    protected EventMarioPlayerPreRespawned(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerRespawned() : 
+    public EventMarioPlayerPreRespawned() : 
         base(62, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -2378,15 +2387,13 @@ namespace Quantum {
       }
     }
   }
-  public unsafe partial class EventMarioPlayerPickedUpObject : EventBase {
+  public unsafe partial class EventMarioPlayerRespawned : EventBase {
     public new const Int32 ID = 63;
     public EntityRef Entity;
-    public EntityRef OtherEntity;
-    public QBoolean HoldAboveHead;
-    protected EventMarioPlayerPickedUpObject(Int32 id, EventFlags flags) : 
+    protected EventMarioPlayerRespawned(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerPickedUpObject() : 
+    public EventMarioPlayerRespawned() : 
         base(63, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -2401,20 +2408,19 @@ namespace Quantum {
       unchecked {
         var hash = 379;
         hash = hash * 31 + Entity.GetHashCode();
-        hash = hash * 31 + OtherEntity.GetHashCode();
-        hash = hash * 31 + HoldAboveHead.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventMarioPlayerThrewObject : EventBase {
+  public unsafe partial class EventMarioPlayerPickedUpObject : EventBase {
     public new const Int32 ID = 64;
     public EntityRef Entity;
     public EntityRef OtherEntity;
-    protected EventMarioPlayerThrewObject(Int32 id, EventFlags flags) : 
+    public QBoolean HoldAboveHead;
+    protected EventMarioPlayerPickedUpObject(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerThrewObject() : 
+    public EventMarioPlayerPickedUpObject() : 
         base(64, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -2430,18 +2436,20 @@ namespace Quantum {
         var hash = 383;
         hash = hash * 31 + Entity.GetHashCode();
         hash = hash * 31 + OtherEntity.GetHashCode();
+        hash = hash * 31 + HoldAboveHead.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventMarioPlayerMegaStart : EventBase {
+  public unsafe partial class EventMarioPlayerThrewObject : EventBase {
     public new const Int32 ID = 65;
     public EntityRef Entity;
-    protected EventMarioPlayerMegaStart(Int32 id, EventFlags flags) : 
+    public EntityRef OtherEntity;
+    protected EventMarioPlayerThrewObject(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerMegaStart() : 
-        base(65, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
+    public EventMarioPlayerThrewObject() : 
+        base(65, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
       get {
@@ -2455,20 +2463,19 @@ namespace Quantum {
       unchecked {
         var hash = 389;
         hash = hash * 31 + Entity.GetHashCode();
+        hash = hash * 31 + OtherEntity.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventMarioPlayerMegaEnd : EventBase {
+  public unsafe partial class EventMarioPlayerMegaStart : EventBase {
     public new const Int32 ID = 66;
     public EntityRef Entity;
-    public QBoolean Cancelled;
-    public Byte EndingFrames;
-    protected EventMarioPlayerMegaEnd(Int32 id, EventFlags flags) : 
+    protected EventMarioPlayerMegaStart(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerMegaEnd() : 
-        base(66, EventFlags.Server|EventFlags.Client) {
+    public EventMarioPlayerMegaStart() : 
+        base(66, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
     }
     public new QuantumGame Game {
       get {
@@ -2482,20 +2489,19 @@ namespace Quantum {
       unchecked {
         var hash = 397;
         hash = hash * 31 + Entity.GetHashCode();
-        hash = hash * 31 + Cancelled.GetHashCode();
-        hash = hash * 31 + EndingFrames.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventMarioPlayerEnteredPipe : EventBase {
+  public unsafe partial class EventMarioPlayerMegaEnd : EventBase {
     public new const Int32 ID = 67;
     public EntityRef Entity;
-    public EntityRef Pipe;
-    protected EventMarioPlayerEnteredPipe(Int32 id, EventFlags flags) : 
+    public QBoolean Cancelled;
+    public Byte EndingFrames;
+    protected EventMarioPlayerMegaEnd(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerEnteredPipe() : 
+    public EventMarioPlayerMegaEnd() : 
         base(67, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -2510,19 +2516,20 @@ namespace Quantum {
       unchecked {
         var hash = 401;
         hash = hash * 31 + Entity.GetHashCode();
-        hash = hash * 31 + Pipe.GetHashCode();
+        hash = hash * 31 + Cancelled.GetHashCode();
+        hash = hash * 31 + EndingFrames.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventMarioPlayerStoppedSliding : EventBase {
+  public unsafe partial class EventMarioPlayerEnteredPipe : EventBase {
     public new const Int32 ID = 68;
     public EntityRef Entity;
-    public QBoolean IsStationary;
-    protected EventMarioPlayerStoppedSliding(Int32 id, EventFlags flags) : 
+    public EntityRef Pipe;
+    protected EventMarioPlayerEnteredPipe(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerStoppedSliding() : 
+    public EventMarioPlayerEnteredPipe() : 
         base(68, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -2537,19 +2544,19 @@ namespace Quantum {
       unchecked {
         var hash = 409;
         hash = hash * 31 + Entity.GetHashCode();
-        hash = hash * 31 + IsStationary.GetHashCode();
+        hash = hash * 31 + Pipe.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventMarioPlayerUsedSpinner : EventBase {
+  public unsafe partial class EventMarioPlayerStoppedSliding : EventBase {
     public new const Int32 ID = 69;
     public EntityRef Entity;
-    public EntityRef Spinner;
-    protected EventMarioPlayerUsedSpinner(Int32 id, EventFlags flags) : 
+    public QBoolean IsStationary;
+    protected EventMarioPlayerStoppedSliding(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerUsedSpinner() : 
+    public EventMarioPlayerStoppedSliding() : 
         base(69, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -2564,18 +2571,19 @@ namespace Quantum {
       unchecked {
         var hash = 419;
         hash = hash * 31 + Entity.GetHashCode();
-        hash = hash * 31 + Spinner.GetHashCode();
+        hash = hash * 31 + IsStationary.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventMarioPlayerStompedByTeammate : EventBase {
+  public unsafe partial class EventMarioPlayerUsedSpinner : EventBase {
     public new const Int32 ID = 70;
     public EntityRef Entity;
-    protected EventMarioPlayerStompedByTeammate(Int32 id, EventFlags flags) : 
+    public EntityRef Spinner;
+    protected EventMarioPlayerUsedSpinner(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerStompedByTeammate() : 
+    public EventMarioPlayerUsedSpinner() : 
         base(70, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -2590,18 +2598,19 @@ namespace Quantum {
       unchecked {
         var hash = 421;
         hash = hash * 31 + Entity.GetHashCode();
+        hash = hash * 31 + Spinner.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventMarioPlayerDestroyed : EventBase {
+  public unsafe partial class EventMarioPlayerStompedByTeammate : EventBase {
     public new const Int32 ID = 71;
     public EntityRef Entity;
-    protected EventMarioPlayerDestroyed(Int32 id, EventFlags flags) : 
+    protected EventMarioPlayerStompedByTeammate(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerDestroyed() : 
-        base(71, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
+    public EventMarioPlayerStompedByTeammate() : 
+        base(71, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
       get {
@@ -2619,14 +2628,14 @@ namespace Quantum {
       }
     }
   }
-  public unsafe partial class EventMarioPlayerLandedWithAnimation : EventBase {
+  public unsafe partial class EventMarioPlayerDestroyed : EventBase {
     public new const Int32 ID = 72;
     public EntityRef Entity;
-    protected EventMarioPlayerLandedWithAnimation(Int32 id, EventFlags flags) : 
+    protected EventMarioPlayerDestroyed(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerLandedWithAnimation() : 
-        base(72, EventFlags.Server|EventFlags.Client) {
+    public EventMarioPlayerDestroyed() : 
+        base(72, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
     }
     public new QuantumGame Game {
       get {
@@ -2644,16 +2653,13 @@ namespace Quantum {
       }
     }
   }
-  public unsafe partial class EventPlayKnockbackEffect : EventBase {
+  public unsafe partial class EventMarioPlayerLandedWithAnimation : EventBase {
     public new const Int32 ID = 73;
     public EntityRef Entity;
-    public EntityRef Attacker;
-    public KnockbackStrength Strength;
-    public NullableFPVector2 AttackerPosition;
-    protected EventPlayKnockbackEffect(Int32 id, EventFlags flags) : 
+    protected EventMarioPlayerLandedWithAnimation(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventPlayKnockbackEffect() : 
+    public EventMarioPlayerLandedWithAnimation() : 
         base(73, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -2668,21 +2674,21 @@ namespace Quantum {
       unchecked {
         var hash = 439;
         hash = hash * 31 + Entity.GetHashCode();
-        hash = hash * 31 + Attacker.GetHashCode();
-        hash = hash * 31 + Strength.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventCoinGroupSpawned : EventBase {
+  public unsafe partial class EventPlayKnockbackEffect : EventBase {
     public new const Int32 ID = 74;
-    public FPVector2 Position;
-    public Int32 CoinCount;
-    protected EventCoinGroupSpawned(Int32 id, EventFlags flags) : 
+    public EntityRef Entity;
+    public EntityRef Attacker;
+    public KnockbackStrength Strength;
+    public NullableFPVector2 AttackerPosition;
+    protected EventPlayKnockbackEffect(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventCoinGroupSpawned() : 
-        base(74, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
+    public EventPlayKnockbackEffect() : 
+        base(74, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
       get {
@@ -2695,20 +2701,22 @@ namespace Quantum {
     public override Int32 GetHashCode() {
       unchecked {
         var hash = 443;
-        hash = hash * 31 + Position.GetHashCode();
-        hash = hash * 31 + CoinCount.GetHashCode();
+        hash = hash * 31 + Entity.GetHashCode();
+        hash = hash * 31 + Attacker.GetHashCode();
+        hash = hash * 31 + Strength.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventMarioPlayerObjectiveCoinsChanged : EventBase {
+  public unsafe partial class EventCoinGroupSpawned : EventBase {
     public new const Int32 ID = 75;
-    public EntityRef Entity;
-    protected EventMarioPlayerObjectiveCoinsChanged(Int32 id, EventFlags flags) : 
+    public FPVector2 Position;
+    public Int32 CoinCount;
+    protected EventCoinGroupSpawned(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerObjectiveCoinsChanged() : 
-        base(75, EventFlags.Server|EventFlags.Client) {
+    public EventCoinGroupSpawned() : 
+        base(75, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
     }
     public new QuantumGame Game {
       get {
@@ -2721,18 +2729,19 @@ namespace Quantum {
     public override Int32 GetHashCode() {
       unchecked {
         var hash = 449;
-        hash = hash * 31 + Entity.GetHashCode();
+        hash = hash * 31 + Position.GetHashCode();
+        hash = hash * 31 + CoinCount.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventPhysicsObjectLanded : EventBase {
+  public unsafe partial class EventMarioPlayerObjectiveCoinsChanged : EventBase {
     public new const Int32 ID = 76;
     public EntityRef Entity;
-    protected EventPhysicsObjectLanded(Int32 id, EventFlags flags) : 
+    protected EventMarioPlayerObjectiveCoinsChanged(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventPhysicsObjectLanded() : 
+    public EventMarioPlayerObjectiveCoinsChanged() : 
         base(76, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -2751,15 +2760,13 @@ namespace Quantum {
       }
     }
   }
-  public unsafe partial class EventProjectileDestroyed : EventBase {
+  public unsafe partial class EventPhysicsObjectLanded : EventBase {
     public new const Int32 ID = 77;
     public EntityRef Entity;
-    public ParticleEffect Particle;
-    public FPVector2 Position;
-    protected EventProjectileDestroyed(Int32 id, EventFlags flags) : 
+    protected EventPhysicsObjectLanded(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventProjectileDestroyed() : 
+    public EventPhysicsObjectLanded() : 
         base(77, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -2774,18 +2781,19 @@ namespace Quantum {
       unchecked {
         var hash = 461;
         hash = hash * 31 + Entity.GetHashCode();
-        hash = hash * 31 + Particle.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventPlayerStartedTyping : EventBase {
+  public unsafe partial class EventProjectileDestroyed : EventBase {
     public new const Int32 ID = 78;
-    public PlayerRef Player;
-    protected EventPlayerStartedTyping(Int32 id, EventFlags flags) : 
+    public EntityRef Entity;
+    public ParticleEffect Particle;
+    public FPVector2 Position;
+    protected EventProjectileDestroyed(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventPlayerStartedTyping() : 
+    public EventProjectileDestroyed() : 
         base(78, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -2799,20 +2807,20 @@ namespace Quantum {
     public override Int32 GetHashCode() {
       unchecked {
         var hash = 463;
-        hash = hash * 31 + Player.GetHashCode();
+        hash = hash * 31 + Entity.GetHashCode();
+        hash = hash * 31 + Particle.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventPlayerSentChatMessage : EventBase {
+  public unsafe partial class EventPlayerStartedTyping : EventBase {
     public new const Int32 ID = 79;
     public PlayerRef Player;
-    public String Message;
-    protected EventPlayerSentChatMessage(Int32 id, EventFlags flags) : 
+    protected EventPlayerStartedTyping(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventPlayerSentChatMessage() : 
-        base(79, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
+    public EventPlayerStartedTyping() : 
+        base(79, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
       get {
@@ -2826,19 +2834,18 @@ namespace Quantum {
       unchecked {
         var hash = 467;
         hash = hash * 31 + Player.GetHashCode();
-        hash = hash * 31 + Message.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventPlayerKickedFromRoom : EventBase {
+  public unsafe partial class EventPlayerSentChatMessage : EventBase {
     public new const Int32 ID = 80;
     public PlayerRef Player;
-    public QBoolean Banned;
-    protected EventPlayerKickedFromRoom(Int32 id, EventFlags flags) : 
+    public String Message;
+    protected EventPlayerSentChatMessage(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventPlayerKickedFromRoom() : 
+    public EventPlayerSentChatMessage() : 
         base(80, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
     }
     public new QuantumGame Game {
@@ -2853,18 +2860,19 @@ namespace Quantum {
       unchecked {
         var hash = 479;
         hash = hash * 31 + Player.GetHashCode();
-        hash = hash * 31 + Banned.GetHashCode();
+        hash = hash * 31 + Message.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventPlayerUnbanned : EventBase {
+  public unsafe partial class EventPlayerKickedFromRoom : EventBase {
     public new const Int32 ID = 81;
-    public BannedPlayerInfo PlayerInfo;
-    protected EventPlayerUnbanned(Int32 id, EventFlags flags) : 
+    public PlayerRef Player;
+    public QBoolean Banned;
+    protected EventPlayerKickedFromRoom(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventPlayerUnbanned() : 
+    public EventPlayerKickedFromRoom() : 
         base(81, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
     }
     public new QuantumGame Game {
@@ -2878,20 +2886,19 @@ namespace Quantum {
     public override Int32 GetHashCode() {
       unchecked {
         var hash = 487;
-        hash = hash * 31 + PlayerInfo.GetHashCode();
+        hash = hash * 31 + Player.GetHashCode();
+        hash = hash * 31 + Banned.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventPlayerTeamChangedByHost : EventBase {
+  public unsafe partial class EventPlayerUnbanned : EventBase {
     public new const Int32 ID = 82;
-    public PlayerRef Player;
-    public Byte Team;
-    public QBoolean Clear;
-    protected EventPlayerTeamChangedByHost(Int32 id, EventFlags flags) : 
+    public BannedPlayerInfo PlayerInfo;
+    protected EventPlayerUnbanned(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventPlayerTeamChangedByHost() : 
+    public EventPlayerUnbanned() : 
         base(82, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
     }
     public new QuantumGame Game {
@@ -2905,21 +2912,20 @@ namespace Quantum {
     public override Int32 GetHashCode() {
       unchecked {
         var hash = 491;
-        hash = hash * 31 + Player.GetHashCode();
-        hash = hash * 31 + Team.GetHashCode();
-        hash = hash * 31 + Clear.GetHashCode();
+        hash = hash * 31 + PlayerInfo.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventMarioPlayerCollectedStarCoin : EventBase {
+  public unsafe partial class EventPlayerTeamChangedByHost : EventBase {
     public new const Int32 ID = 83;
-    public EntityRef Entity;
-    public EntityRef StarCoinEntity;
-    protected EventMarioPlayerCollectedStarCoin(Int32 id, EventFlags flags) : 
+    public PlayerRef Player;
+    public Byte Team;
+    public QBoolean Clear;
+    protected EventPlayerTeamChangedByHost(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerCollectedStarCoin() : 
+    public EventPlayerTeamChangedByHost() : 
         base(83, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
     }
     public new QuantumGame Game {
@@ -2933,21 +2939,22 @@ namespace Quantum {
     public override Int32 GetHashCode() {
       unchecked {
         var hash = 499;
-        hash = hash * 31 + Entity.GetHashCode();
-        hash = hash * 31 + StarCoinEntity.GetHashCode();
+        hash = hash * 31 + Player.GetHashCode();
+        hash = hash * 31 + Team.GetHashCode();
+        hash = hash * 31 + Clear.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventTileChanged : EventBase {
+  public unsafe partial class EventMarioPlayerCollectedStarCoin : EventBase {
     public new const Int32 ID = 84;
-    public IntVector2 Position;
-    public StageTileInstance NewTile;
-    protected EventTileChanged(Int32 id, EventFlags flags) : 
+    public EntityRef Entity;
+    public EntityRef StarCoinEntity;
+    protected EventMarioPlayerCollectedStarCoin(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventTileChanged() : 
-        base(84, EventFlags.Server|EventFlags.Client) {
+    public EventMarioPlayerCollectedStarCoin() : 
+        base(84, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
     }
     public new QuantumGame Game {
       get {
@@ -2960,23 +2967,20 @@ namespace Quantum {
     public override Int32 GetHashCode() {
       unchecked {
         var hash = 503;
-        hash = hash * 31 + Position.GetHashCode();
-        hash = hash * 31 + NewTile.GetHashCode();
+        hash = hash * 31 + Entity.GetHashCode();
+        hash = hash * 31 + StarCoinEntity.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventTileBroken : EventBase {
+  public unsafe partial class EventTileChanged : EventBase {
     public new const Int32 ID = 85;
-    public EntityRef Entity;
     public IntVector2 Position;
-    public StageTileInstance Tile;
-    public QBoolean BrokenByMega;
-    public InteractionDirection Direction;
-    protected EventTileBroken(Int32 id, EventFlags flags) : 
+    public StageTileInstance NewTile;
+    protected EventTileChanged(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventTileBroken() : 
+    public EventTileChanged() : 
         base(85, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -2990,21 +2994,23 @@ namespace Quantum {
     public override Int32 GetHashCode() {
       unchecked {
         var hash = 509;
-        hash = hash * 31 + Entity.GetHashCode();
         hash = hash * 31 + Position.GetHashCode();
-        hash = hash * 31 + Tile.GetHashCode();
-        hash = hash * 31 + BrokenByMega.GetHashCode();
-        hash = hash * 31 + Direction.GetHashCode();
+        hash = hash * 31 + NewTile.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventTimerExpired : EventBase {
+  public unsafe partial class EventTileBroken : EventBase {
     public new const Int32 ID = 86;
-    protected EventTimerExpired(Int32 id, EventFlags flags) : 
+    public EntityRef Entity;
+    public IntVector2 Position;
+    public StageTileInstance Tile;
+    public QBoolean BrokenByMega;
+    public InteractionDirection Direction;
+    protected EventTileBroken(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventTimerExpired() : 
+    public EventTileBroken() : 
         base(86, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -3018,6 +3024,34 @@ namespace Quantum {
     public override Int32 GetHashCode() {
       unchecked {
         var hash = 521;
+        hash = hash * 31 + Entity.GetHashCode();
+        hash = hash * 31 + Position.GetHashCode();
+        hash = hash * 31 + Tile.GetHashCode();
+        hash = hash * 31 + BrokenByMega.GetHashCode();
+        hash = hash * 31 + Direction.GetHashCode();
+        return hash;
+      }
+    }
+  }
+  public unsafe partial class EventTimerExpired : EventBase {
+    public new const Int32 ID = 87;
+    protected EventTimerExpired(Int32 id, EventFlags flags) : 
+        base(id, flags) {
+    }
+    public EventTimerExpired() : 
+        base(87, EventFlags.Server|EventFlags.Client) {
+    }
+    public new QuantumGame Game {
+      get {
+        return (QuantumGame)base.Game;
+      }
+      set {
+        base.Game = value;
+      }
+    }
+    public override Int32 GetHashCode() {
+      unchecked {
+        var hash = 523;
         return hash;
       }
     }

--- a/Assets/QuantumUser/Simulation/Generated/Quantum.CodeGen.Events.cs
+++ b/Assets/QuantumUser/Simulation/Generated/Quantum.CodeGen.Events.cs
@@ -52,7 +52,7 @@ namespace Quantum {
   public unsafe partial class Frame {
     public unsafe partial struct FrameEvents {
       static partial void GetEventTypeCountCodeGen(ref Int32 eventCount) {
-        eventCount = 85;
+        eventCount = 87;
       }
       static partial void GetParentEventIDCodeGen(Int32 eventID, ref Int32 parentEventID) {
         switch (eventID) {
@@ -83,6 +83,8 @@ namespace Quantum {
           case EventPlayComboSound.ID: result = typeof(EventPlayComboSound); return;
           case EventPlayBumpSound.ID: result = typeof(EventPlayBumpSound); return;
           case EventEnemyKicked.ID: result = typeof(EventEnemyKicked); return;
+          case EventEnemyRespawnSparkles.ID: result = typeof(EventEnemyRespawnSparkles); return;
+          case EventEnemyAfterDelayedRespawn.ID: result = typeof(EventEnemyAfterDelayedRespawn); return;
           case EventGameStateChanged.ID: result = typeof(EventGameStateChanged); return;
           case EventPlayerAdded.ID: result = typeof(EventPlayerAdded); return;
           case EventPlayerRemoved.ID: result = typeof(EventPlayerRemoved); return;
@@ -305,6 +307,18 @@ namespace Quantum {
         var ev = _f.Context.AcquireEvent<EventEnemyKicked>(EventEnemyKicked.ID);
         ev.Entity = Entity;
         ev.Groundpounded = Groundpounded;
+        _f.AddEvent(ev);
+        return ev;
+      }
+      public EventEnemyRespawnSparkles EnemyRespawnSparkles(EntityRef Entity) {
+        var ev = _f.Context.AcquireEvent<EventEnemyRespawnSparkles>(EventEnemyRespawnSparkles.ID);
+        ev.Entity = Entity;
+        _f.AddEvent(ev);
+        return ev;
+      }
+      public EventEnemyAfterDelayedRespawn EnemyAfterDelayedRespawn(EntityRef Entity) {
+        var ev = _f.Context.AcquireEvent<EventEnemyAfterDelayedRespawn>(EventEnemyAfterDelayedRespawn.ID);
+        ev.Entity = Entity;
         _f.AddEvent(ev);
         return ev;
       }
@@ -1339,14 +1353,14 @@ namespace Quantum {
       }
     }
   }
-  public unsafe partial class EventGameStateChanged : EventBase {
+  public unsafe partial class EventEnemyRespawnSparkles : EventBase {
     public new const Int32 ID = 23;
-    public GameState NewState;
-    protected EventGameStateChanged(Int32 id, EventFlags flags) : 
+    public EntityRef Entity;
+    protected EventEnemyRespawnSparkles(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventGameStateChanged() : 
-        base(23, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
+    public EventEnemyRespawnSparkles() : 
+        base(23, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
       get {
@@ -1359,19 +1373,19 @@ namespace Quantum {
     public override Int32 GetHashCode() {
       unchecked {
         var hash = 149;
-        hash = hash * 31 + NewState.GetHashCode();
+        hash = hash * 31 + Entity.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventPlayerAdded : EventBase {
+  public unsafe partial class EventEnemyAfterDelayedRespawn : EventBase {
     public new const Int32 ID = 24;
-    public PlayerRef Player;
-    protected EventPlayerAdded(Int32 id, EventFlags flags) : 
+    public EntityRef Entity;
+    protected EventEnemyAfterDelayedRespawn(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventPlayerAdded() : 
-        base(24, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
+    public EventEnemyAfterDelayedRespawn() : 
+        base(24, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
       get {
@@ -1384,18 +1398,18 @@ namespace Quantum {
     public override Int32 GetHashCode() {
       unchecked {
         var hash = 151;
-        hash = hash * 31 + Player.GetHashCode();
+        hash = hash * 31 + Entity.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventPlayerRemoved : EventBase {
+  public unsafe partial class EventGameStateChanged : EventBase {
     public new const Int32 ID = 25;
-    public PlayerRef Player;
-    protected EventPlayerRemoved(Int32 id, EventFlags flags) : 
+    public GameState NewState;
+    protected EventGameStateChanged(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventPlayerRemoved() : 
+    public EventGameStateChanged() : 
         base(25, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
     }
     public new QuantumGame Game {
@@ -1409,19 +1423,19 @@ namespace Quantum {
     public override Int32 GetHashCode() {
       unchecked {
         var hash = 157;
-        hash = hash * 31 + Player.GetHashCode();
+        hash = hash * 31 + NewState.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventPlayerDataChanged : EventBase {
+  public unsafe partial class EventPlayerAdded : EventBase {
     public new const Int32 ID = 26;
     public PlayerRef Player;
-    protected EventPlayerDataChanged(Int32 id, EventFlags flags) : 
+    protected EventPlayerAdded(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventPlayerDataChanged() : 
-        base(26, EventFlags.Server|EventFlags.Client) {
+    public EventPlayerAdded() : 
+        base(26, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
     }
     public new QuantumGame Game {
       get {
@@ -1439,13 +1453,13 @@ namespace Quantum {
       }
     }
   }
-  public unsafe partial class EventStartingCountdownChanged : EventBase {
+  public unsafe partial class EventPlayerRemoved : EventBase {
     public new const Int32 ID = 27;
-    public QBoolean IsGameStarting;
-    protected EventStartingCountdownChanged(Int32 id, EventFlags flags) : 
+    public PlayerRef Player;
+    protected EventPlayerRemoved(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventStartingCountdownChanged() : 
+    public EventPlayerRemoved() : 
         base(27, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
     }
     public new QuantumGame Game {
@@ -1459,18 +1473,18 @@ namespace Quantum {
     public override Int32 GetHashCode() {
       unchecked {
         var hash = 167;
-        hash = hash * 31 + IsGameStarting.GetHashCode();
+        hash = hash * 31 + Player.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventCountdownTick : EventBase {
+  public unsafe partial class EventPlayerDataChanged : EventBase {
     public new const Int32 ID = 28;
-    public Int32 SecondsRemaining;
-    protected EventCountdownTick(Int32 id, EventFlags flags) : 
+    public PlayerRef Player;
+    protected EventPlayerDataChanged(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventCountdownTick() : 
+    public EventPlayerDataChanged() : 
         base(28, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -1484,18 +1498,18 @@ namespace Quantum {
     public override Int32 GetHashCode() {
       unchecked {
         var hash = 173;
-        hash = hash * 31 + SecondsRemaining.GetHashCode();
+        hash = hash * 31 + Player.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventHostChanged : EventBase {
+  public unsafe partial class EventStartingCountdownChanged : EventBase {
     public new const Int32 ID = 29;
-    public PlayerRef NewHost;
-    protected EventHostChanged(Int32 id, EventFlags flags) : 
+    public QBoolean IsGameStarting;
+    protected EventStartingCountdownChanged(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventHostChanged() : 
+    public EventStartingCountdownChanged() : 
         base(29, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
     }
     public new QuantumGame Game {
@@ -1509,20 +1523,19 @@ namespace Quantum {
     public override Int32 GetHashCode() {
       unchecked {
         var hash = 179;
-        hash = hash * 31 + NewHost.GetHashCode();
+        hash = hash * 31 + IsGameStarting.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventRulesChanged : EventBase {
+  public unsafe partial class EventCountdownTick : EventBase {
     public new const Int32 ID = 30;
-    public QBoolean GamemodeChanged;
-    public QBoolean MapChanged;
-    protected EventRulesChanged(Int32 id, EventFlags flags) : 
+    public Int32 SecondsRemaining;
+    protected EventCountdownTick(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventRulesChanged() : 
-        base(30, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
+    public EventCountdownTick() : 
+        base(30, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
       get {
@@ -1535,18 +1548,18 @@ namespace Quantum {
     public override Int32 GetHashCode() {
       unchecked {
         var hash = 181;
-        hash = hash * 31 + GamemodeChanged.GetHashCode();
-        hash = hash * 31 + MapChanged.GetHashCode();
+        hash = hash * 31 + SecondsRemaining.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventHostCloseRulesPanel : EventBase {
+  public unsafe partial class EventHostChanged : EventBase {
     public new const Int32 ID = 31;
-    protected EventHostCloseRulesPanel(Int32 id, EventFlags flags) : 
+    public PlayerRef NewHost;
+    protected EventHostChanged(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventHostCloseRulesPanel() : 
+    public EventHostChanged() : 
         base(31, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
     }
     public new QuantumGame Game {
@@ -1560,17 +1573,19 @@ namespace Quantum {
     public override Int32 GetHashCode() {
       unchecked {
         var hash = 191;
+        hash = hash * 31 + NewHost.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventPlayerLoaded : EventBase {
+  public unsafe partial class EventRulesChanged : EventBase {
     public new const Int32 ID = 32;
-    public PlayerRef Player;
-    protected EventPlayerLoaded(Int32 id, EventFlags flags) : 
+    public QBoolean GamemodeChanged;
+    public QBoolean MapChanged;
+    protected EventRulesChanged(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventPlayerLoaded() : 
+    public EventRulesChanged() : 
         base(32, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
     }
     public new QuantumGame Game {
@@ -1584,17 +1599,18 @@ namespace Quantum {
     public override Int32 GetHashCode() {
       unchecked {
         var hash = 193;
-        hash = hash * 31 + Player.GetHashCode();
+        hash = hash * 31 + GamemodeChanged.GetHashCode();
+        hash = hash * 31 + MapChanged.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventRecordingStarted : EventBase {
+  public unsafe partial class EventHostCloseRulesPanel : EventBase {
     public new const Int32 ID = 33;
-    protected EventRecordingStarted(Int32 id, EventFlags flags) : 
+    protected EventHostCloseRulesPanel(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventRecordingStarted() : 
+    public EventHostCloseRulesPanel() : 
         base(33, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
     }
     public new QuantumGame Game {
@@ -1612,12 +1628,13 @@ namespace Quantum {
       }
     }
   }
-  public unsafe partial class EventGameStarted : EventBase {
+  public unsafe partial class EventPlayerLoaded : EventBase {
     public new const Int32 ID = 34;
-    protected EventGameStarted(Int32 id, EventFlags flags) : 
+    public PlayerRef Player;
+    protected EventPlayerLoaded(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventGameStarted() : 
+    public EventPlayerLoaded() : 
         base(34, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
     }
     public new QuantumGame Game {
@@ -1631,19 +1648,17 @@ namespace Quantum {
     public override Int32 GetHashCode() {
       unchecked {
         var hash = 199;
+        hash = hash * 31 + Player.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventGameEnded : EventBase {
+  public unsafe partial class EventRecordingStarted : EventBase {
     public new const Int32 ID = 35;
-    public QBoolean EndedByHost;
-    public Int32 WinningTeam;
-    public QBoolean HasWinner;
-    protected EventGameEnded(Int32 id, EventFlags flags) : 
+    protected EventRecordingStarted(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventGameEnded() : 
+    public EventRecordingStarted() : 
         base(35, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
     }
     public new QuantumGame Game {
@@ -1657,20 +1672,17 @@ namespace Quantum {
     public override Int32 GetHashCode() {
       unchecked {
         var hash = 211;
-        hash = hash * 31 + EndedByHost.GetHashCode();
-        hash = hash * 31 + WinningTeam.GetHashCode();
-        hash = hash * 31 + HasWinner.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventStartGameEndFade : EventBase {
+  public unsafe partial class EventGameStarted : EventBase {
     public new const Int32 ID = 36;
-    protected EventStartGameEndFade(Int32 id, EventFlags flags) : 
+    protected EventGameStarted(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventStartGameEndFade() : 
-        base(36, EventFlags.Server|EventFlags.Client) {
+    public EventGameStarted() : 
+        base(36, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
     }
     public new QuantumGame Game {
       get {
@@ -1687,12 +1699,15 @@ namespace Quantum {
       }
     }
   }
-  public unsafe partial class EventStageAutoRefresh : EventBase {
+  public unsafe partial class EventGameEnded : EventBase {
     public new const Int32 ID = 37;
-    protected EventStageAutoRefresh(Int32 id, EventFlags flags) : 
+    public QBoolean EndedByHost;
+    public Int32 WinningTeam;
+    public QBoolean HasWinner;
+    protected EventGameEnded(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventStageAutoRefresh() : 
+    public EventGameEnded() : 
         base(37, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
     }
     public new QuantumGame Game {
@@ -1706,18 +1721,19 @@ namespace Quantum {
     public override Int32 GetHashCode() {
       unchecked {
         var hash = 227;
+        hash = hash * 31 + EndedByHost.GetHashCode();
+        hash = hash * 31 + WinningTeam.GetHashCode();
+        hash = hash * 31 + HasWinner.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventMarioPlayerPickedUpGoldBlock : EventBase {
+  public unsafe partial class EventStartGameEndFade : EventBase {
     public new const Int32 ID = 38;
-    public EntityRef Entity;
-    public EntityRef GoldBlock;
-    protected EventMarioPlayerPickedUpGoldBlock(Int32 id, EventFlags flags) : 
+    protected EventStartGameEndFade(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerPickedUpGoldBlock() : 
+    public EventStartGameEndFade() : 
         base(38, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -1731,20 +1747,17 @@ namespace Quantum {
     public override Int32 GetHashCode() {
       unchecked {
         var hash = 229;
-        hash = hash * 31 + Entity.GetHashCode();
-        hash = hash * 31 + GoldBlock.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventGoldBlockGeneratedObjectiveCoin : EventBase {
+  public unsafe partial class EventStageAutoRefresh : EventBase {
     public new const Int32 ID = 39;
-    public EntityRef GoldBlock;
-    protected EventGoldBlockGeneratedObjectiveCoin(Int32 id, EventFlags flags) : 
+    protected EventStageAutoRefresh(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventGoldBlockGeneratedObjectiveCoin() : 
-        base(39, EventFlags.Server|EventFlags.Client) {
+    public EventStageAutoRefresh() : 
+        base(39, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
     }
     public new QuantumGame Game {
       get {
@@ -1757,18 +1770,18 @@ namespace Quantum {
     public override Int32 GetHashCode() {
       unchecked {
         var hash = 233;
-        hash = hash * 31 + GoldBlock.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventGoldBlockRanOutOfCoins : EventBase {
+  public unsafe partial class EventMarioPlayerPickedUpGoldBlock : EventBase {
     public new const Int32 ID = 40;
+    public EntityRef Entity;
     public EntityRef GoldBlock;
-    protected EventGoldBlockRanOutOfCoins(Int32 id, EventFlags flags) : 
+    protected EventMarioPlayerPickedUpGoldBlock(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventGoldBlockRanOutOfCoins() : 
+    public EventMarioPlayerPickedUpGoldBlock() : 
         base(40, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -1782,18 +1795,19 @@ namespace Quantum {
     public override Int32 GetHashCode() {
       unchecked {
         var hash = 239;
+        hash = hash * 31 + Entity.GetHashCode();
         hash = hash * 31 + GoldBlock.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventGoldBlockBrokenByMega : EventBase {
+  public unsafe partial class EventGoldBlockGeneratedObjectiveCoin : EventBase {
     public new const Int32 ID = 41;
     public EntityRef GoldBlock;
-    protected EventGoldBlockBrokenByMega(Int32 id, EventFlags flags) : 
+    protected EventGoldBlockGeneratedObjectiveCoin(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventGoldBlockBrokenByMega() : 
+    public EventGoldBlockGeneratedObjectiveCoin() : 
         base(41, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -1812,14 +1826,14 @@ namespace Quantum {
       }
     }
   }
-  public unsafe partial class EventGoldBlockLostViaDamage : EventBase {
+  public unsafe partial class EventGoldBlockRanOutOfCoins : EventBase {
     public new const Int32 ID = 42;
     public EntityRef GoldBlock;
-    protected EventGoldBlockLostViaDamage(Int32 id, EventFlags flags) : 
+    protected EventGoldBlockRanOutOfCoins(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventGoldBlockLostViaDamage() : 
-        base(42, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
+    public EventGoldBlockRanOutOfCoins() : 
+        base(42, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
       get {
@@ -1837,14 +1851,13 @@ namespace Quantum {
       }
     }
   }
-  public unsafe partial class EventIceBlockSinking : EventBase {
+  public unsafe partial class EventGoldBlockBrokenByMega : EventBase {
     public new const Int32 ID = 43;
-    public EntityRef Entity;
-    public LiquidType LiquidType;
-    protected EventIceBlockSinking(Int32 id, EventFlags flags) : 
+    public EntityRef GoldBlock;
+    protected EventGoldBlockBrokenByMega(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventIceBlockSinking() : 
+    public EventGoldBlockBrokenByMega() : 
         base(43, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -1858,24 +1871,19 @@ namespace Quantum {
     public override Int32 GetHashCode() {
       unchecked {
         var hash = 257;
-        hash = hash * 31 + Entity.GetHashCode();
-        hash = hash * 31 + LiquidType.GetHashCode();
+        hash = hash * 31 + GoldBlock.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventLiquidSplashed : EventBase {
+  public unsafe partial class EventGoldBlockLostViaDamage : EventBase {
     public new const Int32 ID = 44;
-    public EntityRef Entity;
-    public EntityRef Splasher;
-    public FP Force;
-    public FPVector2 Position;
-    public QBoolean Exit;
-    protected EventLiquidSplashed(Int32 id, EventFlags flags) : 
+    public EntityRef GoldBlock;
+    protected EventGoldBlockLostViaDamage(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventLiquidSplashed() : 
-        base(44, EventFlags.Server|EventFlags.Client) {
+    public EventGoldBlockLostViaDamage() : 
+        base(44, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
     }
     public new QuantumGame Game {
       get {
@@ -1888,21 +1896,19 @@ namespace Quantum {
     public override Int32 GetHashCode() {
       unchecked {
         var hash = 263;
-        hash = hash * 31 + Entity.GetHashCode();
-        hash = hash * 31 + Splasher.GetHashCode();
-        hash = hash * 31 + Exit.GetHashCode();
+        hash = hash * 31 + GoldBlock.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventMarioBrosPlatformBumped : EventBase {
+  public unsafe partial class EventIceBlockSinking : EventBase {
     public new const Int32 ID = 45;
     public EntityRef Entity;
-    public FPVector2 Position;
-    protected EventMarioBrosPlatformBumped(Int32 id, EventFlags flags) : 
+    public LiquidType LiquidType;
+    protected EventIceBlockSinking(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioBrosPlatformBumped() : 
+    public EventIceBlockSinking() : 
         base(45, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -1917,21 +1923,22 @@ namespace Quantum {
       unchecked {
         var hash = 269;
         hash = hash * 31 + Entity.GetHashCode();
+        hash = hash * 31 + LiquidType.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventMarioPlayerJumped : EventBase {
+  public unsafe partial class EventLiquidSplashed : EventBase {
     public new const Int32 ID = 46;
     public EntityRef Entity;
-    public PowerupState PowerupState;
-    public JumpState JumpState;
-    public QBoolean WasBounce;
-    public QBoolean IsUnderwater;
-    protected EventMarioPlayerJumped(Int32 id, EventFlags flags) : 
+    public EntityRef Splasher;
+    public FP Force;
+    public FPVector2 Position;
+    public QBoolean Exit;
+    protected EventLiquidSplashed(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerJumped() : 
+    public EventLiquidSplashed() : 
         base(46, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -1946,17 +1953,20 @@ namespace Quantum {
       unchecked {
         var hash = 271;
         hash = hash * 31 + Entity.GetHashCode();
+        hash = hash * 31 + Splasher.GetHashCode();
+        hash = hash * 31 + Exit.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventMarioPlayerGroundpoundStarted : EventBase {
+  public unsafe partial class EventMarioBrosPlatformBumped : EventBase {
     public new const Int32 ID = 47;
     public EntityRef Entity;
-    protected EventMarioPlayerGroundpoundStarted(Int32 id, EventFlags flags) : 
+    public FPVector2 Position;
+    protected EventMarioBrosPlatformBumped(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerGroundpoundStarted() : 
+    public EventMarioBrosPlatformBumped() : 
         base(47, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -1975,14 +1985,17 @@ namespace Quantum {
       }
     }
   }
-  public unsafe partial class EventMarioPlayerGroundpounded : EventBase {
+  public unsafe partial class EventMarioPlayerJumped : EventBase {
     public new const Int32 ID = 48;
     public EntityRef Entity;
     public PowerupState PowerupState;
-    protected EventMarioPlayerGroundpounded(Int32 id, EventFlags flags) : 
+    public JumpState JumpState;
+    public QBoolean WasBounce;
+    public QBoolean IsUnderwater;
+    protected EventMarioPlayerJumped(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerGroundpounded() : 
+    public EventMarioPlayerJumped() : 
         base(48, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -2001,14 +2014,13 @@ namespace Quantum {
       }
     }
   }
-  public unsafe partial class EventMarioPlayerCrouched : EventBase {
+  public unsafe partial class EventMarioPlayerGroundpoundStarted : EventBase {
     public new const Int32 ID = 49;
     public EntityRef Entity;
-    public PowerupState PowerupState;
-    protected EventMarioPlayerCrouched(Int32 id, EventFlags flags) : 
+    protected EventMarioPlayerGroundpoundStarted(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerCrouched() : 
+    public EventMarioPlayerGroundpoundStarted() : 
         base(49, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -2027,16 +2039,15 @@ namespace Quantum {
       }
     }
   }
-  public unsafe partial class EventMarioPlayerCollectedPowerup : EventBase {
+  public unsafe partial class EventMarioPlayerGroundpounded : EventBase {
     public new const Int32 ID = 50;
     public EntityRef Entity;
-    public PowerupReserveResult Result;
-    public PowerupAsset Scriptable;
-    protected EventMarioPlayerCollectedPowerup(Int32 id, EventFlags flags) : 
+    public PowerupState PowerupState;
+    protected EventMarioPlayerGroundpounded(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerCollectedPowerup() : 
-        base(50, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
+    public EventMarioPlayerGroundpounded() : 
+        base(50, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
       get {
@@ -2054,14 +2065,14 @@ namespace Quantum {
       }
     }
   }
-  public unsafe partial class EventMarioPlayerUsedReserveItem : EventBase {
+  public unsafe partial class EventMarioPlayerCrouched : EventBase {
     public new const Int32 ID = 51;
     public EntityRef Entity;
-    public QBoolean Success;
-    protected EventMarioPlayerUsedReserveItem(Int32 id, EventFlags flags) : 
+    public PowerupState PowerupState;
+    protected EventMarioPlayerCrouched(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerUsedReserveItem() : 
+    public EventMarioPlayerCrouched() : 
         base(51, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -2080,17 +2091,16 @@ namespace Quantum {
       }
     }
   }
-  public unsafe partial class EventMarioPlayerWalljumped : EventBase {
+  public unsafe partial class EventMarioPlayerCollectedPowerup : EventBase {
     public new const Int32 ID = 52;
     public EntityRef Entity;
-    public FPVector2 Position;
-    public QBoolean WasOnRightWall;
-    public FPVector2 HitboxExtents;
-    protected EventMarioPlayerWalljumped(Int32 id, EventFlags flags) : 
+    public PowerupReserveResult Result;
+    public PowerupAsset Scriptable;
+    protected EventMarioPlayerCollectedPowerup(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerWalljumped() : 
-        base(52, EventFlags.Server|EventFlags.Client) {
+    public EventMarioPlayerCollectedPowerup() : 
+        base(52, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
     }
     public new QuantumGame Game {
       get {
@@ -2108,14 +2118,14 @@ namespace Quantum {
       }
     }
   }
-  public unsafe partial class EventMarioPlayerShotProjectile : EventBase {
+  public unsafe partial class EventMarioPlayerUsedReserveItem : EventBase {
     public new const Int32 ID = 53;
     public EntityRef Entity;
-    public Projectile Projectile;
-    protected EventMarioPlayerShotProjectile(Int32 id, EventFlags flags) : 
+    public QBoolean Success;
+    protected EventMarioPlayerUsedReserveItem(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerShotProjectile() : 
+    public EventMarioPlayerUsedReserveItem() : 
         base(53, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -2134,13 +2144,16 @@ namespace Quantum {
       }
     }
   }
-  public unsafe partial class EventMarioPlayerUsedPropeller : EventBase {
+  public unsafe partial class EventMarioPlayerWalljumped : EventBase {
     public new const Int32 ID = 54;
     public EntityRef Entity;
-    protected EventMarioPlayerUsedPropeller(Int32 id, EventFlags flags) : 
+    public FPVector2 Position;
+    public QBoolean WasOnRightWall;
+    public FPVector2 HitboxExtents;
+    protected EventMarioPlayerWalljumped(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerUsedPropeller() : 
+    public EventMarioPlayerWalljumped() : 
         base(54, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -2159,13 +2172,14 @@ namespace Quantum {
       }
     }
   }
-  public unsafe partial class EventMarioPlayerPropellerSpin : EventBase {
+  public unsafe partial class EventMarioPlayerShotProjectile : EventBase {
     public new const Int32 ID = 55;
     public EntityRef Entity;
-    protected EventMarioPlayerPropellerSpin(Int32 id, EventFlags flags) : 
+    public Projectile Projectile;
+    protected EventMarioPlayerShotProjectile(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerPropellerSpin() : 
+    public EventMarioPlayerShotProjectile() : 
         base(55, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -2184,15 +2198,14 @@ namespace Quantum {
       }
     }
   }
-  public unsafe partial class EventMarioPlayerDied : EventBase {
+  public unsafe partial class EventMarioPlayerUsedPropeller : EventBase {
     public new const Int32 ID = 56;
     public EntityRef Entity;
-    public QBoolean IsLava;
-    protected EventMarioPlayerDied(Int32 id, EventFlags flags) : 
+    protected EventMarioPlayerUsedPropeller(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerDied() : 
-        base(56, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
+    public EventMarioPlayerUsedPropeller() : 
+        base(56, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
       get {
@@ -2206,19 +2219,17 @@ namespace Quantum {
       unchecked {
         var hash = 337;
         hash = hash * 31 + Entity.GetHashCode();
-        hash = hash * 31 + IsLava.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventMarioPlayerDeathUp : EventBase {
+  public unsafe partial class EventMarioPlayerPropellerSpin : EventBase {
     public new const Int32 ID = 57;
     public EntityRef Entity;
-    public QBoolean FireDeath;
-    protected EventMarioPlayerDeathUp(Int32 id, EventFlags flags) : 
+    protected EventMarioPlayerPropellerSpin(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerDeathUp() : 
+    public EventMarioPlayerPropellerSpin() : 
         base(57, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -2233,18 +2244,18 @@ namespace Quantum {
       unchecked {
         var hash = 347;
         hash = hash * 31 + Entity.GetHashCode();
-        hash = hash * 31 + FireDeath.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventMarioPlayerTookDamage : EventBase {
+  public unsafe partial class EventMarioPlayerDied : EventBase {
     public new const Int32 ID = 58;
     public EntityRef Entity;
-    protected EventMarioPlayerTookDamage(Int32 id, EventFlags flags) : 
+    public QBoolean IsLava;
+    protected EventMarioPlayerDied(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerTookDamage() : 
+    public EventMarioPlayerDied() : 
         base(58, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
     }
     public new QuantumGame Game {
@@ -2259,18 +2270,19 @@ namespace Quantum {
       unchecked {
         var hash = 349;
         hash = hash * 31 + Entity.GetHashCode();
+        hash = hash * 31 + IsLava.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventMarioPlayerPreRespawned : EventBase {
+  public unsafe partial class EventMarioPlayerDeathUp : EventBase {
     public new const Int32 ID = 59;
     public EntityRef Entity;
-    public FPVector2 Spawnpoint;
-    protected EventMarioPlayerPreRespawned(Int32 id, EventFlags flags) : 
+    public QBoolean FireDeath;
+    protected EventMarioPlayerDeathUp(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerPreRespawned() : 
+    public EventMarioPlayerDeathUp() : 
         base(59, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -2285,18 +2297,19 @@ namespace Quantum {
       unchecked {
         var hash = 353;
         hash = hash * 31 + Entity.GetHashCode();
+        hash = hash * 31 + FireDeath.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventMarioPlayerRespawned : EventBase {
+  public unsafe partial class EventMarioPlayerTookDamage : EventBase {
     public new const Int32 ID = 60;
     public EntityRef Entity;
-    protected EventMarioPlayerRespawned(Int32 id, EventFlags flags) : 
+    protected EventMarioPlayerTookDamage(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerRespawned() : 
-        base(60, EventFlags.Server|EventFlags.Client) {
+    public EventMarioPlayerTookDamage() : 
+        base(60, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
     }
     public new QuantumGame Game {
       get {
@@ -2314,15 +2327,14 @@ namespace Quantum {
       }
     }
   }
-  public unsafe partial class EventMarioPlayerPickedUpObject : EventBase {
+  public unsafe partial class EventMarioPlayerPreRespawned : EventBase {
     public new const Int32 ID = 61;
     public EntityRef Entity;
-    public EntityRef OtherEntity;
-    public QBoolean HoldAboveHead;
-    protected EventMarioPlayerPickedUpObject(Int32 id, EventFlags flags) : 
+    public FPVector2 Spawnpoint;
+    protected EventMarioPlayerPreRespawned(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerPickedUpObject() : 
+    public EventMarioPlayerPreRespawned() : 
         base(61, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -2337,20 +2349,17 @@ namespace Quantum {
       unchecked {
         var hash = 367;
         hash = hash * 31 + Entity.GetHashCode();
-        hash = hash * 31 + OtherEntity.GetHashCode();
-        hash = hash * 31 + HoldAboveHead.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventMarioPlayerThrewObject : EventBase {
+  public unsafe partial class EventMarioPlayerRespawned : EventBase {
     public new const Int32 ID = 62;
     public EntityRef Entity;
-    public EntityRef OtherEntity;
-    protected EventMarioPlayerThrewObject(Int32 id, EventFlags flags) : 
+    protected EventMarioPlayerRespawned(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerThrewObject() : 
+    public EventMarioPlayerRespawned() : 
         base(62, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -2365,19 +2374,20 @@ namespace Quantum {
       unchecked {
         var hash = 373;
         hash = hash * 31 + Entity.GetHashCode();
-        hash = hash * 31 + OtherEntity.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventMarioPlayerMegaStart : EventBase {
+  public unsafe partial class EventMarioPlayerPickedUpObject : EventBase {
     public new const Int32 ID = 63;
     public EntityRef Entity;
-    protected EventMarioPlayerMegaStart(Int32 id, EventFlags flags) : 
+    public EntityRef OtherEntity;
+    public QBoolean HoldAboveHead;
+    protected EventMarioPlayerPickedUpObject(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerMegaStart() : 
-        base(63, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
+    public EventMarioPlayerPickedUpObject() : 
+        base(63, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
       get {
@@ -2391,19 +2401,20 @@ namespace Quantum {
       unchecked {
         var hash = 379;
         hash = hash * 31 + Entity.GetHashCode();
+        hash = hash * 31 + OtherEntity.GetHashCode();
+        hash = hash * 31 + HoldAboveHead.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventMarioPlayerMegaEnd : EventBase {
+  public unsafe partial class EventMarioPlayerThrewObject : EventBase {
     public new const Int32 ID = 64;
     public EntityRef Entity;
-    public QBoolean Cancelled;
-    public Byte EndingFrames;
-    protected EventMarioPlayerMegaEnd(Int32 id, EventFlags flags) : 
+    public EntityRef OtherEntity;
+    protected EventMarioPlayerThrewObject(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerMegaEnd() : 
+    public EventMarioPlayerThrewObject() : 
         base(64, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -2418,21 +2429,19 @@ namespace Quantum {
       unchecked {
         var hash = 383;
         hash = hash * 31 + Entity.GetHashCode();
-        hash = hash * 31 + Cancelled.GetHashCode();
-        hash = hash * 31 + EndingFrames.GetHashCode();
+        hash = hash * 31 + OtherEntity.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventMarioPlayerEnteredPipe : EventBase {
+  public unsafe partial class EventMarioPlayerMegaStart : EventBase {
     public new const Int32 ID = 65;
     public EntityRef Entity;
-    public EntityRef Pipe;
-    protected EventMarioPlayerEnteredPipe(Int32 id, EventFlags flags) : 
+    protected EventMarioPlayerMegaStart(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerEnteredPipe() : 
-        base(65, EventFlags.Server|EventFlags.Client) {
+    public EventMarioPlayerMegaStart() : 
+        base(65, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
     }
     public new QuantumGame Game {
       get {
@@ -2446,19 +2455,19 @@ namespace Quantum {
       unchecked {
         var hash = 389;
         hash = hash * 31 + Entity.GetHashCode();
-        hash = hash * 31 + Pipe.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventMarioPlayerStoppedSliding : EventBase {
+  public unsafe partial class EventMarioPlayerMegaEnd : EventBase {
     public new const Int32 ID = 66;
     public EntityRef Entity;
-    public QBoolean IsStationary;
-    protected EventMarioPlayerStoppedSliding(Int32 id, EventFlags flags) : 
+    public QBoolean Cancelled;
+    public Byte EndingFrames;
+    protected EventMarioPlayerMegaEnd(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerStoppedSliding() : 
+    public EventMarioPlayerMegaEnd() : 
         base(66, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -2473,19 +2482,20 @@ namespace Quantum {
       unchecked {
         var hash = 397;
         hash = hash * 31 + Entity.GetHashCode();
-        hash = hash * 31 + IsStationary.GetHashCode();
+        hash = hash * 31 + Cancelled.GetHashCode();
+        hash = hash * 31 + EndingFrames.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventMarioPlayerUsedSpinner : EventBase {
+  public unsafe partial class EventMarioPlayerEnteredPipe : EventBase {
     public new const Int32 ID = 67;
     public EntityRef Entity;
-    public EntityRef Spinner;
-    protected EventMarioPlayerUsedSpinner(Int32 id, EventFlags flags) : 
+    public EntityRef Pipe;
+    protected EventMarioPlayerEnteredPipe(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerUsedSpinner() : 
+    public EventMarioPlayerEnteredPipe() : 
         base(67, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -2500,18 +2510,19 @@ namespace Quantum {
       unchecked {
         var hash = 401;
         hash = hash * 31 + Entity.GetHashCode();
-        hash = hash * 31 + Spinner.GetHashCode();
+        hash = hash * 31 + Pipe.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventMarioPlayerStompedByTeammate : EventBase {
+  public unsafe partial class EventMarioPlayerStoppedSliding : EventBase {
     public new const Int32 ID = 68;
     public EntityRef Entity;
-    protected EventMarioPlayerStompedByTeammate(Int32 id, EventFlags flags) : 
+    public QBoolean IsStationary;
+    protected EventMarioPlayerStoppedSliding(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerStompedByTeammate() : 
+    public EventMarioPlayerStoppedSliding() : 
         base(68, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -2526,18 +2537,20 @@ namespace Quantum {
       unchecked {
         var hash = 409;
         hash = hash * 31 + Entity.GetHashCode();
+        hash = hash * 31 + IsStationary.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventMarioPlayerDestroyed : EventBase {
+  public unsafe partial class EventMarioPlayerUsedSpinner : EventBase {
     public new const Int32 ID = 69;
     public EntityRef Entity;
-    protected EventMarioPlayerDestroyed(Int32 id, EventFlags flags) : 
+    public EntityRef Spinner;
+    protected EventMarioPlayerUsedSpinner(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerDestroyed() : 
-        base(69, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
+    public EventMarioPlayerUsedSpinner() : 
+        base(69, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
       get {
@@ -2551,17 +2564,18 @@ namespace Quantum {
       unchecked {
         var hash = 419;
         hash = hash * 31 + Entity.GetHashCode();
+        hash = hash * 31 + Spinner.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventMarioPlayerLandedWithAnimation : EventBase {
+  public unsafe partial class EventMarioPlayerStompedByTeammate : EventBase {
     public new const Int32 ID = 70;
     public EntityRef Entity;
-    protected EventMarioPlayerLandedWithAnimation(Int32 id, EventFlags flags) : 
+    protected EventMarioPlayerStompedByTeammate(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerLandedWithAnimation() : 
+    public EventMarioPlayerStompedByTeammate() : 
         base(70, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -2580,17 +2594,14 @@ namespace Quantum {
       }
     }
   }
-  public unsafe partial class EventPlayKnockbackEffect : EventBase {
+  public unsafe partial class EventMarioPlayerDestroyed : EventBase {
     public new const Int32 ID = 71;
     public EntityRef Entity;
-    public EntityRef Attacker;
-    public KnockbackStrength Strength;
-    public NullableFPVector2 AttackerPosition;
-    protected EventPlayKnockbackEffect(Int32 id, EventFlags flags) : 
+    protected EventMarioPlayerDestroyed(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventPlayKnockbackEffect() : 
-        base(71, EventFlags.Server|EventFlags.Client) {
+    public EventMarioPlayerDestroyed() : 
+        base(71, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
     }
     public new QuantumGame Game {
       get {
@@ -2604,21 +2615,18 @@ namespace Quantum {
       unchecked {
         var hash = 431;
         hash = hash * 31 + Entity.GetHashCode();
-        hash = hash * 31 + Attacker.GetHashCode();
-        hash = hash * 31 + Strength.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventCoinGroupSpawned : EventBase {
+  public unsafe partial class EventMarioPlayerLandedWithAnimation : EventBase {
     public new const Int32 ID = 72;
-    public FPVector2 Position;
-    public Int32 CoinCount;
-    protected EventCoinGroupSpawned(Int32 id, EventFlags flags) : 
+    public EntityRef Entity;
+    protected EventMarioPlayerLandedWithAnimation(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventCoinGroupSpawned() : 
-        base(72, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
+    public EventMarioPlayerLandedWithAnimation() : 
+        base(72, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
       get {
@@ -2631,19 +2639,21 @@ namespace Quantum {
     public override Int32 GetHashCode() {
       unchecked {
         var hash = 433;
-        hash = hash * 31 + Position.GetHashCode();
-        hash = hash * 31 + CoinCount.GetHashCode();
+        hash = hash * 31 + Entity.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventMarioPlayerObjectiveCoinsChanged : EventBase {
+  public unsafe partial class EventPlayKnockbackEffect : EventBase {
     public new const Int32 ID = 73;
     public EntityRef Entity;
-    protected EventMarioPlayerObjectiveCoinsChanged(Int32 id, EventFlags flags) : 
+    public EntityRef Attacker;
+    public KnockbackStrength Strength;
+    public NullableFPVector2 AttackerPosition;
+    protected EventPlayKnockbackEffect(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerObjectiveCoinsChanged() : 
+    public EventPlayKnockbackEffect() : 
         base(73, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -2658,18 +2668,21 @@ namespace Quantum {
       unchecked {
         var hash = 439;
         hash = hash * 31 + Entity.GetHashCode();
+        hash = hash * 31 + Attacker.GetHashCode();
+        hash = hash * 31 + Strength.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventPhysicsObjectLanded : EventBase {
+  public unsafe partial class EventCoinGroupSpawned : EventBase {
     public new const Int32 ID = 74;
-    public EntityRef Entity;
-    protected EventPhysicsObjectLanded(Int32 id, EventFlags flags) : 
+    public FPVector2 Position;
+    public Int32 CoinCount;
+    protected EventCoinGroupSpawned(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventPhysicsObjectLanded() : 
-        base(74, EventFlags.Server|EventFlags.Client) {
+    public EventCoinGroupSpawned() : 
+        base(74, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
     }
     public new QuantumGame Game {
       get {
@@ -2682,20 +2695,19 @@ namespace Quantum {
     public override Int32 GetHashCode() {
       unchecked {
         var hash = 443;
-        hash = hash * 31 + Entity.GetHashCode();
+        hash = hash * 31 + Position.GetHashCode();
+        hash = hash * 31 + CoinCount.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventProjectileDestroyed : EventBase {
+  public unsafe partial class EventMarioPlayerObjectiveCoinsChanged : EventBase {
     public new const Int32 ID = 75;
     public EntityRef Entity;
-    public ParticleEffect Particle;
-    public FPVector2 Position;
-    protected EventProjectileDestroyed(Int32 id, EventFlags flags) : 
+    protected EventMarioPlayerObjectiveCoinsChanged(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventProjectileDestroyed() : 
+    public EventMarioPlayerObjectiveCoinsChanged() : 
         base(75, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -2710,18 +2722,17 @@ namespace Quantum {
       unchecked {
         var hash = 449;
         hash = hash * 31 + Entity.GetHashCode();
-        hash = hash * 31 + Particle.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventPlayerStartedTyping : EventBase {
+  public unsafe partial class EventPhysicsObjectLanded : EventBase {
     public new const Int32 ID = 76;
-    public PlayerRef Player;
-    protected EventPlayerStartedTyping(Int32 id, EventFlags flags) : 
+    public EntityRef Entity;
+    protected EventPhysicsObjectLanded(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventPlayerStartedTyping() : 
+    public EventPhysicsObjectLanded() : 
         base(76, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -2735,20 +2746,21 @@ namespace Quantum {
     public override Int32 GetHashCode() {
       unchecked {
         var hash = 457;
-        hash = hash * 31 + Player.GetHashCode();
+        hash = hash * 31 + Entity.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventPlayerSentChatMessage : EventBase {
+  public unsafe partial class EventProjectileDestroyed : EventBase {
     public new const Int32 ID = 77;
-    public PlayerRef Player;
-    public String Message;
-    protected EventPlayerSentChatMessage(Int32 id, EventFlags flags) : 
+    public EntityRef Entity;
+    public ParticleEffect Particle;
+    public FPVector2 Position;
+    protected EventProjectileDestroyed(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventPlayerSentChatMessage() : 
-        base(77, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
+    public EventProjectileDestroyed() : 
+        base(77, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
       get {
@@ -2761,21 +2773,20 @@ namespace Quantum {
     public override Int32 GetHashCode() {
       unchecked {
         var hash = 461;
-        hash = hash * 31 + Player.GetHashCode();
-        hash = hash * 31 + Message.GetHashCode();
+        hash = hash * 31 + Entity.GetHashCode();
+        hash = hash * 31 + Particle.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventPlayerKickedFromRoom : EventBase {
+  public unsafe partial class EventPlayerStartedTyping : EventBase {
     public new const Int32 ID = 78;
     public PlayerRef Player;
-    public QBoolean Banned;
-    protected EventPlayerKickedFromRoom(Int32 id, EventFlags flags) : 
+    protected EventPlayerStartedTyping(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventPlayerKickedFromRoom() : 
-        base(78, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
+    public EventPlayerStartedTyping() : 
+        base(78, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
       get {
@@ -2789,18 +2800,18 @@ namespace Quantum {
       unchecked {
         var hash = 463;
         hash = hash * 31 + Player.GetHashCode();
-        hash = hash * 31 + Banned.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventPlayerUnbanned : EventBase {
+  public unsafe partial class EventPlayerSentChatMessage : EventBase {
     public new const Int32 ID = 79;
-    public BannedPlayerInfo PlayerInfo;
-    protected EventPlayerUnbanned(Int32 id, EventFlags flags) : 
+    public PlayerRef Player;
+    public String Message;
+    protected EventPlayerSentChatMessage(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventPlayerUnbanned() : 
+    public EventPlayerSentChatMessage() : 
         base(79, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
     }
     public new QuantumGame Game {
@@ -2814,20 +2825,20 @@ namespace Quantum {
     public override Int32 GetHashCode() {
       unchecked {
         var hash = 467;
-        hash = hash * 31 + PlayerInfo.GetHashCode();
+        hash = hash * 31 + Player.GetHashCode();
+        hash = hash * 31 + Message.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventPlayerTeamChangedByHost : EventBase {
+  public unsafe partial class EventPlayerKickedFromRoom : EventBase {
     public new const Int32 ID = 80;
     public PlayerRef Player;
-    public Byte Team;
-    public QBoolean Clear;
-    protected EventPlayerTeamChangedByHost(Int32 id, EventFlags flags) : 
+    public QBoolean Banned;
+    protected EventPlayerKickedFromRoom(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventPlayerTeamChangedByHost() : 
+    public EventPlayerKickedFromRoom() : 
         base(80, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
     }
     public new QuantumGame Game {
@@ -2842,20 +2853,18 @@ namespace Quantum {
       unchecked {
         var hash = 479;
         hash = hash * 31 + Player.GetHashCode();
-        hash = hash * 31 + Team.GetHashCode();
-        hash = hash * 31 + Clear.GetHashCode();
+        hash = hash * 31 + Banned.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventMarioPlayerCollectedStarCoin : EventBase {
+  public unsafe partial class EventPlayerUnbanned : EventBase {
     public new const Int32 ID = 81;
-    public EntityRef Entity;
-    public EntityRef StarCoinEntity;
-    protected EventMarioPlayerCollectedStarCoin(Int32 id, EventFlags flags) : 
+    public BannedPlayerInfo PlayerInfo;
+    protected EventPlayerUnbanned(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventMarioPlayerCollectedStarCoin() : 
+    public EventPlayerUnbanned() : 
         base(81, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
     }
     public new QuantumGame Game {
@@ -2869,21 +2878,21 @@ namespace Quantum {
     public override Int32 GetHashCode() {
       unchecked {
         var hash = 487;
-        hash = hash * 31 + Entity.GetHashCode();
-        hash = hash * 31 + StarCoinEntity.GetHashCode();
+        hash = hash * 31 + PlayerInfo.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventTileChanged : EventBase {
+  public unsafe partial class EventPlayerTeamChangedByHost : EventBase {
     public new const Int32 ID = 82;
-    public IntVector2 Position;
-    public StageTileInstance NewTile;
-    protected EventTileChanged(Int32 id, EventFlags flags) : 
+    public PlayerRef Player;
+    public Byte Team;
+    public QBoolean Clear;
+    protected EventPlayerTeamChangedByHost(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventTileChanged() : 
-        base(82, EventFlags.Server|EventFlags.Client) {
+    public EventPlayerTeamChangedByHost() : 
+        base(82, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
     }
     public new QuantumGame Game {
       get {
@@ -2896,24 +2905,22 @@ namespace Quantum {
     public override Int32 GetHashCode() {
       unchecked {
         var hash = 491;
-        hash = hash * 31 + Position.GetHashCode();
-        hash = hash * 31 + NewTile.GetHashCode();
+        hash = hash * 31 + Player.GetHashCode();
+        hash = hash * 31 + Team.GetHashCode();
+        hash = hash * 31 + Clear.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventTileBroken : EventBase {
+  public unsafe partial class EventMarioPlayerCollectedStarCoin : EventBase {
     public new const Int32 ID = 83;
     public EntityRef Entity;
-    public IntVector2 Position;
-    public StageTileInstance Tile;
-    public QBoolean BrokenByMega;
-    public InteractionDirection Direction;
-    protected EventTileBroken(Int32 id, EventFlags flags) : 
+    public EntityRef StarCoinEntity;
+    protected EventMarioPlayerCollectedStarCoin(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventTileBroken() : 
-        base(83, EventFlags.Server|EventFlags.Client) {
+    public EventMarioPlayerCollectedStarCoin() : 
+        base(83, EventFlags.Server|EventFlags.Client|EventFlags.Synced) {
     }
     public new QuantumGame Game {
       get {
@@ -2927,20 +2934,19 @@ namespace Quantum {
       unchecked {
         var hash = 499;
         hash = hash * 31 + Entity.GetHashCode();
-        hash = hash * 31 + Position.GetHashCode();
-        hash = hash * 31 + Tile.GetHashCode();
-        hash = hash * 31 + BrokenByMega.GetHashCode();
-        hash = hash * 31 + Direction.GetHashCode();
+        hash = hash * 31 + StarCoinEntity.GetHashCode();
         return hash;
       }
     }
   }
-  public unsafe partial class EventTimerExpired : EventBase {
+  public unsafe partial class EventTileChanged : EventBase {
     public new const Int32 ID = 84;
-    protected EventTimerExpired(Int32 id, EventFlags flags) : 
+    public IntVector2 Position;
+    public StageTileInstance NewTile;
+    protected EventTileChanged(Int32 id, EventFlags flags) : 
         base(id, flags) {
     }
-    public EventTimerExpired() : 
+    public EventTileChanged() : 
         base(84, EventFlags.Server|EventFlags.Client) {
     }
     public new QuantumGame Game {
@@ -2954,6 +2960,64 @@ namespace Quantum {
     public override Int32 GetHashCode() {
       unchecked {
         var hash = 503;
+        hash = hash * 31 + Position.GetHashCode();
+        hash = hash * 31 + NewTile.GetHashCode();
+        return hash;
+      }
+    }
+  }
+  public unsafe partial class EventTileBroken : EventBase {
+    public new const Int32 ID = 85;
+    public EntityRef Entity;
+    public IntVector2 Position;
+    public StageTileInstance Tile;
+    public QBoolean BrokenByMega;
+    public InteractionDirection Direction;
+    protected EventTileBroken(Int32 id, EventFlags flags) : 
+        base(id, flags) {
+    }
+    public EventTileBroken() : 
+        base(85, EventFlags.Server|EventFlags.Client) {
+    }
+    public new QuantumGame Game {
+      get {
+        return (QuantumGame)base.Game;
+      }
+      set {
+        base.Game = value;
+      }
+    }
+    public override Int32 GetHashCode() {
+      unchecked {
+        var hash = 509;
+        hash = hash * 31 + Entity.GetHashCode();
+        hash = hash * 31 + Position.GetHashCode();
+        hash = hash * 31 + Tile.GetHashCode();
+        hash = hash * 31 + BrokenByMega.GetHashCode();
+        hash = hash * 31 + Direction.GetHashCode();
+        return hash;
+      }
+    }
+  }
+  public unsafe partial class EventTimerExpired : EventBase {
+    public new const Int32 ID = 86;
+    protected EventTimerExpired(Int32 id, EventFlags flags) : 
+        base(id, flags) {
+    }
+    public EventTimerExpired() : 
+        base(86, EventFlags.Server|EventFlags.Client) {
+    }
+    public new QuantumGame Game {
+      get {
+        return (QuantumGame)base.Game;
+      }
+      set {
+        base.Game = value;
+      }
+    }
+    public override Int32 GetHashCode() {
+      unchecked {
+        var hash = 521;
         return hash;
       }
     }

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Bobomb/Bobomb.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Bobomb/Bobomb.cs
@@ -71,6 +71,7 @@ namespace Quantum {
             f.Events.PlayComboSound(bobombEntity, combo);
 
             enemy->IsDead = true;
+            enemy->SetDelayedRespawn();
 
             // Holdable
             var holdable = f.Unsafe.GetPointer<Holdable>(bobombEntity);

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Bobomb/BobombSystem.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Bobomb/BobombSystem.cs
@@ -2,7 +2,7 @@ using Photon.Deterministic;
 
 namespace Quantum {
     public unsafe class BobombSystem : SystemMainThreadEntityFilter<Bobomb, BobombSystem.Filter>, ISignalOnEntityBumped, ISignalOnEnemyRespawned, ISignalOnThrowHoldable, 
-        ISignalOnBobombExplodeEntity, ISignalOnIceBlockBroken, ISignalOnEnemyKilledByStageReset, ISignalOnEntityCrushed, ISignalOnMarioPlayerBecameInvincible, ISignalOnEnemyAfterDelayedRespawn {
+        ISignalOnBobombExplodeEntity, ISignalOnIceBlockBroken, ISignalOnEnemyKilledByStageReset, ISignalOnEntityCrushed, ISignalOnMarioPlayerBecameInvincible {
         
         public struct Filter {
             public EntityRef Entity;
@@ -358,12 +358,6 @@ namespace Quantum {
             var mario = f.Unsafe.GetPointer<MarioPlayer>(entity);
             if (f.Unsafe.TryGetPointer(mario->HeldEntity, out Bobomb* bobomb)) {
                 bobomb->Kill(f, mario->HeldEntity, entity, EnemyKillReason.Special);
-            }
-        }
-
-        public void OnEnemyAfterDelayedRespawn(Frame f, EntityRef entity) {
-            if (f.Unsafe.TryGetPointer(entity, out Bobomb* bobomb)) {
-                bobomb->Respawn(f, entity);
             }
         }
         #endregion

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Bobomb/BobombSystem.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Bobomb/BobombSystem.cs
@@ -2,7 +2,7 @@ using Photon.Deterministic;
 
 namespace Quantum {
     public unsafe class BobombSystem : SystemMainThreadEntityFilter<Bobomb, BobombSystem.Filter>, ISignalOnEntityBumped, ISignalOnEnemyRespawned, ISignalOnThrowHoldable, 
-        ISignalOnBobombExplodeEntity, ISignalOnIceBlockBroken, ISignalOnEnemyKilledByStageReset, ISignalOnEntityCrushed, ISignalOnMarioPlayerBecameInvincible {
+        ISignalOnBobombExplodeEntity, ISignalOnIceBlockBroken, ISignalOnEnemyKilledByStageReset, ISignalOnEntityCrushed, ISignalOnMarioPlayerBecameInvincible, ISignalOnEnemyAfterDelayedRespawn {
         
         public struct Filter {
             public EntityRef Entity;
@@ -122,6 +122,7 @@ namespace Quantum {
 
             enemy->IsDead = true;
             enemy->IsActive = false;
+            enemy->SetDelayedRespawn(180); // three seconds instead of the usual 6
             physicsObject->Velocity = FPVector2.Zero;
             physicsObject->IsFrozen = true;
             f.Events.BobombExploded(filter.Entity);
@@ -357,6 +358,12 @@ namespace Quantum {
             var mario = f.Unsafe.GetPointer<MarioPlayer>(entity);
             if (f.Unsafe.TryGetPointer(mario->HeldEntity, out Bobomb* bobomb)) {
                 bobomb->Kill(f, mario->HeldEntity, entity, EnemyKillReason.Special);
+            }
+        }
+
+        public void OnEnemyAfterDelayedRespawn(Frame f, EntityRef entity) {
+            if (f.Unsafe.TryGetPointer(entity, out Bobomb* bobomb)) {
+                bobomb->Respawn(f, entity);
             }
         }
         #endregion

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Boo/Boo.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Boo/Boo.cs
@@ -35,6 +35,7 @@ namespace Quantum {
             f.Events.PlayComboSound(booEntity, combo);
 
             enemy->IsDead = true;
+            enemy->SetDelayedRespawn(sparklesTime: 120);
 
             var collider = f.Unsafe.GetPointer<PhysicsCollider2D>(booEntity);
             FPVector2 center = booTransform->Position + collider->Shape.Centroid;

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Enemy.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Enemy.cs
@@ -42,7 +42,7 @@ namespace Quantum {
             RespawnSparklesTimer = sparklesTime;
         }
 
-        public void Respawn(Frame f, EntityRef entity, bool fromStar) {
+        public void Respawn(Frame f, EntityRef entity) {
             var transform = f.Unsafe.GetPointer<Transform2D>(entity);
 
             IsActive = true;

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Enemy.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Enemy.cs
@@ -34,8 +34,8 @@ namespace Quantum {
          * <summary>
          * Sets the respawn data for the enemy
          * </summary>
-         * <param name="waitTime">How long to wait until the enemy respawns in seconds.</param>
-         * <param name="sparklesTime">When the sparkles will spawn (based off time remaining) also in seconds.</param>
+         * <param name="waitTime">How long to wait until the enemy respawns in frames.</param>
+         * <param name="sparklesTime">When the sparkles will spawn (based off time remaining) also in frames.</param>
          */
         public void SetDelayedRespawn(int waitTime = 420, int sparklesTime = 80) {
             RespawnTimer = waitTime;
@@ -47,6 +47,7 @@ namespace Quantum {
 
             IsActive = true;
             IsDead = false;
+            LeftHome = false;
             SetDelayedRespawn(0, 0);
             transform->Teleport(f, Spawnpoint);
 

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Enemy.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Enemy.cs
@@ -1,15 +1,18 @@
 using Photon.Deterministic;
+using UnityEngine.Diagnostics;
 using UnityEngine.UIElements;
 
 namespace Quantum {
     public unsafe partial struct Enemy {
         public readonly bool IsAlive => !IsDead && IsActive;
 
-        public EntityRef findClosestPlayer(Frame f, EntityRef entity) {
+        public EntityRef FindClosestPlayer(Frame f, EntityRef entity, VersusStageData stage = null) {
             var allPlayers = f.Filter<MarioPlayer, Transform2D>();
             allPlayers.UseCulling = false;
 
-            VersusStageData stage = f.FindAsset<VersusStageData>(f.Map.UserAsset);
+            if (stage == null) {
+                stage = f.FindAsset<VersusStageData>(f.Map.UserAsset);
+            }
             FP closestDistance = FP.MaxValue;
             EntityRef closestPlayer = EntityRef.None;
             while (allPlayers.NextUnsafe(out EntityRef marioEntity, out MarioPlayer* mario, out Transform2D* marioTransform)) {
@@ -27,11 +30,24 @@ namespace Quantum {
             return closestPlayer;
         }
 
-        public void Respawn(Frame f, EntityRef entity) {
+        /**
+         * <summary>
+         * Sets the respawn data for the enemy
+         * </summary>
+         * <param name="waitTime">How long to wait until the enemy respawns in seconds.</param>
+         * <param name="sparklesTime">When the sparkles will spawn (based off time remaining) also in seconds.</param>
+         */
+        public void SetDelayedRespawn(int waitTime = 420, int sparklesTime = 80) {
+            RespawnTimer = waitTime;
+            RespawnSparklesTimer = sparklesTime;
+        }
+
+        public void Respawn(Frame f, EntityRef entity, bool fromStar) {
             var transform = f.Unsafe.GetPointer<Transform2D>(entity);
 
             IsActive = true;
             IsDead = false;
+            SetDelayedRespawn(0, 0);
             transform->Teleport(f, Spawnpoint);
 
             if (f.Unsafe.TryGetPointer(entity, out PhysicsObject* physicsObject)) {
@@ -42,7 +58,7 @@ namespace Quantum {
 
             // face left by default
             var shouldFaceRight = false;
-            var closestMario = findClosestPlayer(f, entity);
+            var closestMario = FindClosestPlayer(f, entity);
 
             // use closest player and face them
             if (f.Unsafe.TryGetPointer(closestMario, out Transform2D* marioTransform)) {

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Enemy.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Enemy.cs
@@ -1,15 +1,37 @@
 using Photon.Deterministic;
+using UnityEngine.UIElements;
 
 namespace Quantum {
     public unsafe partial struct Enemy {
         public readonly bool IsAlive => !IsDead && IsActive;
+
+        public EntityRef findClosestPlayer(Frame f, EntityRef entity) {
+            var allPlayers = f.Filter<MarioPlayer, Transform2D>();
+            allPlayers.UseCulling = false;
+
+            VersusStageData stage = f.FindAsset<VersusStageData>(f.Map.UserAsset);
+            FP closestDistance = FP.MaxValue;
+            EntityRef closestPlayer = EntityRef.None;
+            while (allPlayers.NextUnsafe(out EntityRef marioEntity, out MarioPlayer* mario, out Transform2D* marioTransform)) {
+                if (mario->IsDead) {
+                    continue;
+                }
+
+                FP newDistance = QuantumUtils.WrappedDistance(stage, Spawnpoint, marioTransform->Position);
+
+                if (newDistance <= closestDistance) {
+                    closestPlayer = marioEntity;
+                    closestDistance = newDistance;
+                }
+            }
+            return closestPlayer;
+        }
 
         public void Respawn(Frame f, EntityRef entity) {
             var transform = f.Unsafe.GetPointer<Transform2D>(entity);
 
             IsActive = true;
             IsDead = false;
-            FacingRight = false;
             transform->Teleport(f, Spawnpoint);
 
             if (f.Unsafe.TryGetPointer(entity, out PhysicsObject* physicsObject)) {
@@ -17,6 +39,18 @@ namespace Quantum {
                 physicsObject->Velocity = FPVector2.Zero;
                 physicsObject->DisableCollision = false;
             }
+
+            // face left by default
+            var shouldFaceRight = false;
+            var closestMario = findClosestPlayer(f, entity);
+
+            // use closest player and face them
+            if (f.Unsafe.TryGetPointer(closestMario, out Transform2D* marioTransform)) {
+                QuantumUtils.WrappedDistance(f, Spawnpoint, marioTransform->Position, out FP xDiff);
+                shouldFaceRight = xDiff < 0;
+            }
+
+            FacingRight = shouldFaceRight;
         }
 
         public void ChangeFacingRight(Frame f, EntityRef entity, bool newFacingRight) {

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Enemy.qtn
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Enemy.qtn
@@ -1,5 +1,5 @@
 #define EnemyHomeBoxWidth 8
-#define EnemyHomeBoxBuffer 10
+#define EnemyHomeBoxBuffer 8
 #define EnemyHomeBoxLeaveWidth 3
 
 component Enemy {
@@ -11,6 +11,7 @@ component Enemy {
 	[ExcludeFromPrototype] bool IsActive;
 	[ExcludeFromPrototype] bool IsDead;
 	[ExcludeFromPrototype] bool FacingRight;
+	[ExcludeFromPrototype] bool LeftHome;
 	[ExcludeFromPrototype] int RespawnTimer;
 	[ExcludeFromPrototype] int RespawnSparklesTimer;
 }
@@ -54,6 +55,11 @@ event PlayBumpSound {
 event EnemyKicked {
 	EntityRef Entity;
 	bool Groundpounded;
+}
+
+event EnemySufferedOffscreen {
+	EntityRef Entity;
+	nothashed FPVector2 Position;
 }
 
 event EnemyRespawnSparkles {

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Enemy.qtn
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Enemy.qtn
@@ -1,4 +1,6 @@
-#define EnemyHomeRadius 12
+#define EnemyHomeBoxWidth 8
+#define EnemyHomeBoxBuffer 10
+#define EnemyHomeBoxLeaveWidth 3
 
 component Enemy {
 	FPVector2 Spawnpoint;

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Enemy.qtn
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Enemy.qtn
@@ -23,7 +23,6 @@ signal OnEnemyKilledByStageReset(EntityRef entity);
 signal OnEnemyTurnaround(EntityRef entity);
 signal OnEnemyReturnedHome(EntityRef entity);
 signal OnEnemyRespawnSparkles(EntityRef entity);
-signal OnEnemyAfterDelayedRespawn(EntityRef entity);
 
 enum EnemyKillReason : Byte {
 	Normal,

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Enemy.qtn
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Enemy.qtn
@@ -1,4 +1,4 @@
-#define EnemyHomeBoxWidth 8
+#define EnemyMaxDistFromMario 8
 #define EnemyHomeBoxBuffer 8
 #define EnemyHomeBoxLeaveWidth 3
 

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Enemy.qtn
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Enemy.qtn
@@ -9,6 +9,8 @@ component Enemy {
 	[ExcludeFromPrototype] bool IsActive;
 	[ExcludeFromPrototype] bool IsDead;
 	[ExcludeFromPrototype] bool FacingRight;
+	[ExcludeFromPrototype] int RespawnTimer;
+	[ExcludeFromPrototype] int RespawnSparklesTimer;
 }
 
 signal OnEnemyDespawned(EntityRef entity);
@@ -17,6 +19,8 @@ signal OnEnemyEnemyCollision(EntityRef a, EntityRef b);
 signal OnEnemyKilledByStageReset(EntityRef entity);
 signal OnEnemyTurnaround(EntityRef entity);
 signal OnEnemyReturnedHome(EntityRef entity);
+signal OnEnemyRespawnSparkles(EntityRef entity);
+signal OnEnemyAfterDelayedRespawn(EntityRef entity);
 
 enum EnemyKillReason : Byte {
 	Normal,
@@ -48,4 +52,12 @@ event PlayBumpSound {
 event EnemyKicked {
 	EntityRef Entity;
 	bool Groundpounded;
+}
+
+event EnemyRespawnSparkles {
+	EntityRef Entity;
+}
+
+event EnemyAfterDelayedRespawn {
+	EntityRef Entity;
 }

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/EnemySystem.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/EnemySystem.cs
@@ -101,6 +101,8 @@ namespace Quantum {
         public override void Update(Frame f, ref Filter filter, VersusStageData stage) {
             var enemy = filter.Enemy;
 
+            // handle respawning
+            if (enemy->RespawnTimer > 0) HandleDelayedRespawn(f, filter, stage);
             if (!enemy->IsActive) {
                 return;
             }
@@ -112,6 +114,7 @@ namespace Quantum {
             if (transform->Position.Y + collider->Shape.Box.Extents.Y + collider->Shape.Centroid.Y < stage.StageWorldMin.Y) {
                 enemy->IsActive = false;
                 enemy->IsDead = true;
+                enemy->SetDelayedRespawn();
                 if (f.Unsafe.TryGetPointer(filter.Entity, out PhysicsObject* physicsObject)) {
                     physicsObject->IsFrozen = true;
                 }
@@ -149,30 +152,21 @@ namespace Quantum {
             }
         }
 
-        public EntityRef findClosestPlayer(Frame f, Filter filter) {
-            var allPlayers = f.Filter<MarioPlayer, Transform2D>();
-            allPlayers.UseCulling = false;
-
-            VersusStageData stage = f.FindAsset<VersusStageData>(f.Map.UserAsset);
-            FP closestDistance = FP.MaxValue;
-            EntityRef closestPlayer = EntityRef.None;
-            while (allPlayers.NextUnsafe(out EntityRef marioEntity, out MarioPlayer* mario, out Transform2D* marioTransform)) {
-                if (mario->IsDead) {
-                    continue;
-                }
-
-                FP newDistance = QuantumUtils.WrappedDistance(stage, filter.Enemy->Spawnpoint, marioTransform->Position);
-
-                if (newDistance <= closestDistance) {
-                    closestPlayer = marioEntity;
-                    closestDistance = newDistance;
-                }
+        public void HandleDelayedRespawn(Frame f, Filter filter, VersusStageData stage) {
+            var enemy = filter.Enemy;
+            if (QuantumUtils.Decrement(ref enemy->RespawnTimer)) {
+                enemy->Respawn(f, filter.Entity, false);
+                f.Signals.OnEnemyAfterDelayedRespawn(filter.Entity);
             }
-            return closestPlayer;
+
+            if (enemy->RespawnTimer == enemy->RespawnSparklesTimer && enemy->RespawnSparklesTimer != 0) {
+                f.Events.EnemyRespawnSparkles(filter.Entity);
+            }
         }
 
         public void OffscreenCheck(Frame f, Filter filter, VersusStageData stage)
         {
+            var enemy = filter.Enemy;
             var allPlayersFilter = f.Filter<MarioPlayer, Transform2D>();
             while (allPlayersFilter.NextUnsafe(out _, out _, out Transform2D* marioTransform)) {
                 QuantumUtils.WrappedDistance(stage, filter.Transform->Position, marioTransform->Position, out FP distance);
@@ -184,18 +178,18 @@ namespace Quantum {
                 if (physicsObject->IsFrozen) return;
                 physicsObject->Velocity = FPVector2.Zero;
             }
-            if (filter.Transform->Position != filter.Enemy->Spawnpoint) f.Signals.OnEnemyReturnedHome(filter.Entity);
-            filter.Transform->Teleport(f, filter.Enemy->Spawnpoint);
+            if (filter.Transform->Position != enemy->Spawnpoint) f.Signals.OnEnemyReturnedHome(filter.Entity);
+            filter.Transform->Teleport(f, enemy->Spawnpoint);
 
             var shouldFaceRight = false;
-            var closestMario = findClosestPlayer(f, filter);
+            var closestMario = enemy->FindClosestPlayer(f, filter.Entity, stage);
 
             // turn to face player while in the shadows...
             if (f.Unsafe.TryGetPointer(closestMario, out Transform2D* closestMarioTransform)) {
-                QuantumUtils.WrappedDistance(f, filter.Enemy->Spawnpoint, closestMarioTransform->Position, out FP distance);
+                QuantumUtils.WrappedDistance(f, enemy->Spawnpoint, closestMarioTransform->Position, out FP distance);
                 shouldFaceRight = distance < 0;
             }
-            filter.Enemy->FacingRight = shouldFaceRight;
+            enemy->FacingRight = shouldFaceRight;
         }
 
         public void OnStageReset(Frame f, QBoolean full) {
@@ -228,7 +222,7 @@ namespace Quantum {
                         }
                     }
 
-                    enemy->Respawn(f, entity);
+                    enemy->Respawn(f, entity, true);
                     f.Signals.OnEnemyRespawned(entity);
                 }
             }

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/EnemySystem.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/EnemySystem.cs
@@ -158,6 +158,7 @@ namespace Quantum {
             if (QuantumUtils.Decrement(ref enemy->RespawnTimer)) {
                 enemy->Respawn(f, filter.Entity, false);
                 f.Events.EnemyAfterDelayedRespawn(filter.Entity);
+                f.Signals.OnEnemyAfterDelayedRespawn(filter.Entity);
             }
 
             if (enemy->RespawnTimer == enemy->RespawnSparklesTimer && enemy->RespawnSparklesTimer != 0) {
@@ -175,24 +176,38 @@ namespace Quantum {
 
             // check if any Mario is near the enemy
             while (allPlayersFilter.NextUnsafe(out _, out _, out Transform2D* marioTransform)) {
+                // despawn if out of view of Mario
                 QuantumUtils.WrappedDistance(stage, transform->Position, marioTransform->Position, out FP distanceToMario);
                 if (FPMath.Abs(distanceToMario) < Constants.EnemyHomeBoxWidth) {
                     return;
                 }
 
-                QuantumUtils.WrappedDistance(stage, enemy->Spawnpoint, marioTransform->Position, out FP marioDistanceToSpawnpoint);
-                if (FPMath.Abs(marioDistanceToSpawnpoint) < Constants.EnemyHomeBoxBuffer) {
+                // check if a Mario is in the spawnpoint
+                QuantumUtils.WrappedDistance(stage, enemy->Spawnpoint, marioTransform->Position, out FP marioDistToSpawnpoint);
+                if (FPMath.Abs(marioDistToSpawnpoint) < Constants.EnemyHomeBoxBuffer) {
                     marioInSpawnpoint = true;
+                    break;
                 }
             }
 
-            if (marioInSpawnpoint) {
-                // just teleport if the enemy didn't leave its home
-                if (f.Unsafe.TryGetPointer(filter.Entity, out PhysicsObject* physicsObject)) {
-                    if (physicsObject->IsFrozen) return;
-                    physicsObject->Velocity = FPVector2.Zero;
-                }
+            bool foundPhysicsObj;
 
+            // freeze check! Do not teleport frozen enemies.
+            if (foundPhysicsObj=f.Unsafe.TryGetPointer(filter.Entity, out PhysicsObject* physicsObject)) {
+                if (physicsObject->IsFrozen) return;
+            }
+
+            // check if the enemy left its home
+            if (!enemy->LeftHome) {
+                QuantumUtils.WrappedDistance(stage, enemy->Spawnpoint, transform->Position, out FP enemyDistToSpawnpoint);
+                if (FPMath.Abs(enemyDistToSpawnpoint) > Constants.EnemyHomeBoxLeaveWidth) {
+                    enemy->LeftHome = true;
+                }
+            }
+
+            if (!marioInSpawnpoint &! enemy->LeftHome) {
+                // set to 0
+                if (foundPhysicsObj) physicsObject->Velocity = FPVector2.Zero;
                 // turn to face the player while in the shadows
                 var shouldFaceRight = false;
                 var closestMario = enemy->FindClosestPlayer(f, entity);
@@ -211,7 +226,8 @@ namespace Quantum {
                 // "kill" the enemy if a Mario is in its spawnpoint
                 enemy->IsActive = false;
                 enemy->IsDead = true;
-                enemy->SetDelayedRespawn();
+                enemy->SetDelayedRespawn(300); // lower respawn time
+                f.Events.EnemySufferedOffscreen(entity, f.Unsafe.GetPointer<Transform2D>(entity)->Position);
             }
         }
 

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/EnemySystem.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/EnemySystem.cs
@@ -40,6 +40,9 @@ namespace Quantum {
 
         public override void Update(FrameThreadSafe f, ref Filter filter) {
             var enemy = filter.Enemy;
+
+            // handle respawning
+            if (enemy->RespawnTimer > 0 &! enemy->DisableRespawning) HandleDelayedRespawn(f, filter, stage);
             if (!enemy->IsActive) {
                 return;
             }
@@ -48,17 +51,15 @@ namespace Quantum {
             var collider = filter.Collider;
 
             // Despawn off bottom of stage
-            VersusStageData stage = f.FindAsset<VersusStageData>(f.Map.UserAsset); // TODO: somehow save between entities.
             if (transform->Position.Y + collider->Shape.Box.Extents.Y + collider->Shape.Centroid.Y < stage.StageWorldMin.Y) {
                 enemy->IsActive = false;
                 enemy->IsDead = true;
-                if (f.TryGetPointer(filter.Entity, out PhysicsObject* physicsObject)) {
+                if (!enemy->DisableRespawning) enemy->SetDelayedRespawn();
+                if (f.Unsafe.TryGetPointer(filter.Entity, out PhysicsObject* physicsObject)) {
                     physicsObject->IsFrozen = true;
                 }
 
-                lock (despawningEntities) {
-                    despawningEntities.Add(filter.Entity);
-                }
+                f.Signals.OnEnemyDespawned(filter.Entity);
                 return;
             }
 
@@ -102,7 +103,7 @@ namespace Quantum {
             var enemy = filter.Enemy;
 
             // handle respawning
-            if (enemy->RespawnTimer > 0) HandleDelayedRespawn(f, filter, stage);
+            if (enemy->RespawnTimer > 0 &! enemy->DisableRespawning) HandleDelayedRespawn(f, filter, stage);
             if (!enemy->IsActive) {
                 return;
             }
@@ -114,7 +115,7 @@ namespace Quantum {
             if (transform->Position.Y + collider->Shape.Box.Extents.Y + collider->Shape.Centroid.Y < stage.StageWorldMin.Y) {
                 enemy->IsActive = false;
                 enemy->IsDead = true;
-                enemy->SetDelayedRespawn();
+                if (!enemy->DisableRespawning) enemy->SetDelayedRespawn();
                 if (f.Unsafe.TryGetPointer(filter.Entity, out PhysicsObject* physicsObject)) {
                     physicsObject->IsFrozen = true;
                 }
@@ -156,7 +157,7 @@ namespace Quantum {
             var enemy = filter.Enemy;
             if (QuantumUtils.Decrement(ref enemy->RespawnTimer)) {
                 enemy->Respawn(f, filter.Entity, false);
-                f.Signals.OnEnemyAfterDelayedRespawn(filter.Entity);
+                f.Events.EnemyAfterDelayedRespawn(filter.Entity);
             }
 
             if (enemy->RespawnTimer == enemy->RespawnSparklesTimer && enemy->RespawnSparklesTimer != 0) {
@@ -164,32 +165,54 @@ namespace Quantum {
             }
         }
 
-        public void OffscreenCheck(Frame f, Filter filter, VersusStageData stage)
-        {
+        public void OffscreenCheck(Frame f, Filter filter, VersusStageData stage) {
             var enemy = filter.Enemy;
             var allPlayersFilter = f.Filter<MarioPlayer, Transform2D>();
+            var transform = filter.Transform;
+            var entity = filter.Entity;
+
+            bool marioInSpawnpoint = false;
+
+            // check if any Mario is near the enemy
             while (allPlayersFilter.NextUnsafe(out _, out _, out Transform2D* marioTransform)) {
-                QuantumUtils.WrappedDistance(stage, filter.Transform->Position, marioTransform->Position, out FP distance);
-                if (FPMath.Abs(distance) < Constants.EnemyHomeRadius) return;
+                QuantumUtils.WrappedDistance(stage, transform->Position, marioTransform->Position, out FP distanceToMario);
+                if (FPMath.Abs(distanceToMario) < Constants.EnemyHomeBoxWidth) {
+                    return;
+                }
+
+                QuantumUtils.WrappedDistance(stage, enemy->Spawnpoint, marioTransform->Position, out FP marioDistanceToSpawnpoint);
+                if (FPMath.Abs(marioDistanceToSpawnpoint) < Constants.EnemyHomeBoxBuffer) {
+                    marioInSpawnpoint = true;
+                }
             }
 
-            if (f.Unsafe.TryGetPointer(filter.Entity, out PhysicsObject* physicsObject))
-            {
-                if (physicsObject->IsFrozen) return;
-                physicsObject->Velocity = FPVector2.Zero;
-            }
-            if (filter.Transform->Position != enemy->Spawnpoint) f.Signals.OnEnemyReturnedHome(filter.Entity);
-            filter.Transform->Teleport(f, enemy->Spawnpoint);
+            if (marioInSpawnpoint) {
+                // just teleport if the enemy didn't leave its home
+                if (f.Unsafe.TryGetPointer(filter.Entity, out PhysicsObject* physicsObject)) {
+                    if (physicsObject->IsFrozen) return;
+                    physicsObject->Velocity = FPVector2.Zero;
+                }
 
-            var shouldFaceRight = false;
-            var closestMario = enemy->FindClosestPlayer(f, filter.Entity, stage);
+                // turn to face the player while in the shadows
+                var shouldFaceRight = false;
+                var closestMario = enemy->FindClosestPlayer(f, entity);
 
-            // turn to face player while in the shadows...
-            if (f.Unsafe.TryGetPointer(closestMario, out Transform2D* closestMarioTransform)) {
-                QuantumUtils.WrappedDistance(f, enemy->Spawnpoint, closestMarioTransform->Position, out FP distance);
-                shouldFaceRight = distance < 0;
+                // use closest player and face them
+                if (f.Unsafe.TryGetPointer(closestMario, out Transform2D* closestMarioTransform)) {
+                    QuantumUtils.WrappedDistance(f, enemy->Spawnpoint, closestMarioTransform->Position, out FP xDiff);
+                    shouldFaceRight = xDiff < 0;
+                }
+
+                enemy->FacingRight = shouldFaceRight;
+
+                transform->Teleport(f, enemy->Spawnpoint);
+                f.Signals.OnEnemyReturnedHome(entity);
+            } else {
+                // "kill" the enemy if a Mario is in its spawnpoint
+                enemy->IsActive = false;
+                enemy->IsDead = true;
+                enemy->SetDelayedRespawn();
             }
-            enemy->FacingRight = shouldFaceRight;
         }
 
         public void OnStageReset(Frame f, QBoolean full) {

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/EnemySystem.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/EnemySystem.cs
@@ -149,13 +149,34 @@ namespace Quantum {
             }
         }
 
+        public EntityRef findClosestPlayer(Frame f, Filter filter) {
+            var allPlayers = f.Filter<MarioPlayer, Transform2D>();
+            allPlayers.UseCulling = false;
+
+            VersusStageData stage = f.FindAsset<VersusStageData>(f.Map.UserAsset);
+            FP closestDistance = FP.MaxValue;
+            EntityRef closestPlayer = EntityRef.None;
+            while (allPlayers.NextUnsafe(out EntityRef marioEntity, out MarioPlayer* mario, out Transform2D* marioTransform)) {
+                if (mario->IsDead) {
+                    continue;
+                }
+
+                FP newDistance = QuantumUtils.WrappedDistance(stage, filter.Enemy->Spawnpoint, marioTransform->Position);
+
+                if (newDistance <= closestDistance) {
+                    closestPlayer = marioEntity;
+                    closestDistance = newDistance;
+                }
+            }
+            return closestPlayer;
+        }
+
         public void OffscreenCheck(Frame f, Filter filter, VersusStageData stage)
         {
             var allPlayersFilter = f.Filter<MarioPlayer, Transform2D>();
             while (allPlayersFilter.NextUnsafe(out _, out _, out Transform2D* marioTransform)) {
                 QuantumUtils.WrappedDistance(stage, filter.Transform->Position, marioTransform->Position, out FP distance);
-                QuantumUtils.WrappedDistance(stage, filter.Enemy->Spawnpoint, marioTransform->Position, out FP spawnpointDistance);
-                if (FPMath.Abs(distance) < Constants.EnemyHomeRadius || FPMath.Abs(spawnpointDistance) < Constants.EnemyHomeRadius) return;
+                if (FPMath.Abs(distance) < Constants.EnemyHomeRadius) return;
             }
 
             if (f.Unsafe.TryGetPointer(filter.Entity, out PhysicsObject* physicsObject))
@@ -165,7 +186,16 @@ namespace Quantum {
             }
             if (filter.Transform->Position != filter.Enemy->Spawnpoint) f.Signals.OnEnemyReturnedHome(filter.Entity);
             filter.Transform->Teleport(f, filter.Enemy->Spawnpoint);
-            filter.Enemy->FacingRight = false;
+
+            var shouldFaceRight = false;
+            var closestMario = findClosestPlayer(f, filter);
+
+            // turn to face player while in the shadows...
+            if (f.Unsafe.TryGetPointer(closestMario, out Transform2D* closestMarioTransform)) {
+                QuantumUtils.WrappedDistance(f, filter.Enemy->Spawnpoint, closestMarioTransform->Position, out FP distance);
+                shouldFaceRight = distance < 0;
+            }
+            filter.Enemy->FacingRight = shouldFaceRight;
         }
 
         public void OnStageReset(Frame f, QBoolean full) {

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/EnemySystem.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/EnemySystem.cs
@@ -156,9 +156,9 @@ namespace Quantum {
         public void HandleDelayedRespawn(Frame f, Filter filter, VersusStageData stage) {
             var enemy = filter.Enemy;
             if (QuantumUtils.Decrement(ref enemy->RespawnTimer)) {
-                enemy->Respawn(f, filter.Entity, false);
+                enemy->Respawn(f, filter.Entity);
                 f.Events.EnemyAfterDelayedRespawn(filter.Entity);
-                f.Signals.OnEnemyAfterDelayedRespawn(filter.Entity);
+                f.Signals.OnEnemyRespawned(filter.Entity);
             }
 
             if (enemy->RespawnTimer == enemy->RespawnSparklesTimer && enemy->RespawnSparklesTimer != 0) {
@@ -228,10 +228,12 @@ namespace Quantum {
                 enemy->IsDead = true;
                 enemy->SetDelayedRespawn(300); // lower respawn time
                 f.Events.EnemySufferedOffscreen(entity, f.Unsafe.GetPointer<Transform2D>(entity)->Position);
+                f.Signals.OnEnemyDespawned(entity);
             }
         }
 
         public void OnStageReset(Frame f, QBoolean full) {
+            if (!full) return; // ignore non-full resets
             var filter = f.Filter<Enemy, Transform2D>();
 
             while (filter.NextUnsafe(out EntityRef entity, out Enemy* enemy, out Transform2D* transform)) {
@@ -261,7 +263,7 @@ namespace Quantum {
                         }
                     }
 
-                    enemy->Respawn(f, entity, true);
+                    enemy->Respawn(f, entity);
                     f.Signals.OnEnemyRespawned(entity);
                 }
             }

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/EnemySystem.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/EnemySystem.cs
@@ -175,10 +175,11 @@ namespace Quantum {
             bool marioInSpawnpoint = false;
 
             // check if any Mario is near the enemy
+            allPlayersFilter.UseCulling = false;
             while (allPlayersFilter.NextUnsafe(out _, out _, out Transform2D* marioTransform)) {
                 // despawn if out of view of Mario
                 QuantumUtils.WrappedDistance(stage, transform->Position, marioTransform->Position, out FP distanceToMario);
-                if (FPMath.Abs(distanceToMario) < Constants.EnemyHomeBoxWidth) {
+                if (FPMath.Abs(distanceToMario) < Constants.EnemyMaxDistFromMario) {
                     return;
                 }
 
@@ -186,7 +187,6 @@ namespace Quantum {
                 QuantumUtils.WrappedDistance(stage, enemy->Spawnpoint, marioTransform->Position, out FP marioDistToSpawnpoint);
                 if (FPMath.Abs(marioDistToSpawnpoint) < Constants.EnemyHomeBoxBuffer) {
                     marioInSpawnpoint = true;
-                    break;
                 }
             }
 

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Goomba/Goomba.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Goomba/Goomba.cs
@@ -52,6 +52,7 @@ namespace Quantum {
             }
 
             enemy->IsDead = true;
+            enemy->SetDelayedRespawn();
             f.Unsafe.GetPointer<Interactable>(goombaEntity)->ColliderDisabled = true;
 
             var collider = f.Unsafe.GetPointer<PhysicsCollider2D>(goombaEntity);

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Goomba/GoombaSystem.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Goomba/GoombaSystem.cs
@@ -2,7 +2,7 @@ using Photon.Deterministic;
 
 namespace Quantum {
     public unsafe class GoombaSystem : SystemMainThreadEntityFilter<Goomba, GoombaSystem.Filter>, ISignalOnEntityBumped, ISignalOnBobombExplodeEntity,
-        ISignalOnIceBlockBroken, ISignalOnEnemyKilledByStageReset, ISignalOnEntityCrushed, ISignalOnEnemyRespawned, ISignalOnEnemyAfterDelayedRespawn {
+        ISignalOnIceBlockBroken, ISignalOnEnemyKilledByStageReset, ISignalOnEntityCrushed, ISignalOnEnemyRespawned {
 
         public struct Filter {
 			public EntityRef Entity;
@@ -170,12 +170,6 @@ namespace Quantum {
         }
 
         public void OnEnemyRespawned(Frame f, EntityRef entity) {
-            if (f.Unsafe.TryGetPointer(entity, out Goomba* goomba)) {
-                goomba->Respawn(f, entity);
-            }
-        }
-
-        public void OnEnemyAfterDelayedRespawn(Frame f, EntityRef entity) {
             if (f.Unsafe.TryGetPointer(entity, out Goomba* goomba)) {
                 goomba->Respawn(f, entity);
             }

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Goomba/GoombaSystem.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Goomba/GoombaSystem.cs
@@ -2,7 +2,7 @@ using Photon.Deterministic;
 
 namespace Quantum {
     public unsafe class GoombaSystem : SystemMainThreadEntityFilter<Goomba, GoombaSystem.Filter>, ISignalOnEntityBumped, ISignalOnBobombExplodeEntity,
-        ISignalOnIceBlockBroken, ISignalOnEnemyKilledByStageReset, ISignalOnEntityCrushed, ISignalOnEnemyRespawned {
+        ISignalOnIceBlockBroken, ISignalOnEnemyKilledByStageReset, ISignalOnEntityCrushed, ISignalOnEnemyRespawned, ISignalOnEnemyAfterDelayedRespawn {
 
         public struct Filter {
 			public EntityRef Entity;
@@ -170,6 +170,12 @@ namespace Quantum {
         }
 
         public void OnEnemyRespawned(Frame f, EntityRef entity) {
+            if (f.Unsafe.TryGetPointer(entity, out Goomba* goomba)) {
+                goomba->Respawn(f, entity);
+            }
+        }
+
+        public void OnEnemyAfterDelayedRespawn(Frame f, EntityRef entity) {
             if (f.Unsafe.TryGetPointer(entity, out Goomba* goomba)) {
                 goomba->Respawn(f, entity);
             }

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Koopa/Koopa.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Koopa/Koopa.cs
@@ -99,6 +99,7 @@ namespace Quantum {
             IsInShell = false;
             IsKicked = false;
             IsFlipped = false;
+            enemy->SetDelayedRespawn();
 
             f.Events.EnemyKilled(koopaEntity, killerEntity, reason, center);
         }

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Koopa/KoopaSystem.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Koopa/KoopaSystem.cs
@@ -4,7 +4,7 @@ using Quantum.Collections;
 namespace Quantum {
     public unsafe class KoopaSystem : SystemMainThreadEntityFilter<Koopa, KoopaSystem.Filter>, ISignalOnThrowHoldable, ISignalOnEnemyRespawned, ISignalOnEntityBumped,
         ISignalOnBobombExplodeEntity, ISignalOnIceBlockBroken, ISignalOnEnemyKilledByStageReset, ISignalOnEnemyTurnaround, ISignalOnEntityCrushed,
-        ISignalOnMarioPlayerBecameInvincible, ISignalOnEnemyReturnedHome, ISignalOnEnemyAfterDelayedRespawn {
+        ISignalOnMarioPlayerBecameInvincible, ISignalOnEnemyReturnedHome {
        
         public struct Filter {
             public EntityRef Entity;
@@ -528,12 +528,6 @@ namespace Quantum {
 
         public void OnEnemyReturnedHome(Frame f, EntityRef entity) {
             if (f.Unsafe.TryGetPointer(entity, out Koopa* koopa) && koopa->IsInShell) {
-                koopa->Respawn(f, entity);
-            }
-        }
-
-        public void OnEnemyAfterDelayedRespawn(Frame f, EntityRef entity) {
-            if (f.Unsafe.TryGetPointer(entity, out Koopa* koopa)) {
                 koopa->Respawn(f, entity);
             }
         }

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Koopa/KoopaSystem.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Koopa/KoopaSystem.cs
@@ -533,7 +533,7 @@ namespace Quantum {
         }
 
         public void OnEnemyAfterDelayedRespawn(Frame f, EntityRef entity) {
-            if (f.Unsafe.TryGetPointer(entity, out Koopa* koopa) && koopa->IsInShell) {
+            if (f.Unsafe.TryGetPointer(entity, out Koopa* koopa)) {
                 koopa->Respawn(f, entity);
             }
         }

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Koopa/KoopaSystem.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Koopa/KoopaSystem.cs
@@ -251,6 +251,7 @@ namespace Quantum {
                     PowerupReserveResult result = powerup.Collect(f, marioEntity);
                     koopaEnemy->IsActive = false;
                     koopaEnemy->IsDead = true;
+                    koopaEnemy->SetDelayedRespawn(600); // a little longer...
                     koopaPhysicsObject->IsFrozen = true;
                     f.Events.MarioPlayerCollectedPowerup(marioEntity, result, powerup);
                 } else {
@@ -282,6 +283,7 @@ namespace Quantum {
 
                         koopaEnemy->IsActive = false;
                         koopaEnemy->IsDead = true;
+                        koopaEnemy->SetDelayedRespawn(600); // a little longer...
                         koopaPhysicsObject->IsFrozen = true;
 
                     } else if (mario->CurrentPowerupState != PowerupState.MiniMushroom || mario->IsGroundpoundActive) {

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Koopa/KoopaSystem.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Koopa/KoopaSystem.cs
@@ -4,7 +4,7 @@ using Quantum.Collections;
 namespace Quantum {
     public unsafe class KoopaSystem : SystemMainThreadEntityFilter<Koopa, KoopaSystem.Filter>, ISignalOnThrowHoldable, ISignalOnEnemyRespawned, ISignalOnEntityBumped,
         ISignalOnBobombExplodeEntity, ISignalOnIceBlockBroken, ISignalOnEnemyKilledByStageReset, ISignalOnEnemyTurnaround, ISignalOnEntityCrushed,
-        ISignalOnMarioPlayerBecameInvincible, ISignalOnEnemyReturnedHome {
+        ISignalOnMarioPlayerBecameInvincible, ISignalOnEnemyReturnedHome, ISignalOnEnemyAfterDelayedRespawn {
        
         public struct Filter {
             public EntityRef Entity;
@@ -527,6 +527,12 @@ namespace Quantum {
         }
 
         public void OnEnemyReturnedHome(Frame f, EntityRef entity) {
+            if (f.Unsafe.TryGetPointer(entity, out Koopa* koopa) && koopa->IsInShell) {
+                koopa->Respawn(f, entity);
+            }
+        }
+
+        public void OnEnemyAfterDelayedRespawn(Frame f, EntityRef entity) {
             if (f.Unsafe.TryGetPointer(entity, out Koopa* koopa) && koopa->IsInShell) {
                 koopa->Respawn(f, entity);
             }

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/PiranhaPlant/PiranhaPlant.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/PiranhaPlant/PiranhaPlant.cs
@@ -34,6 +34,7 @@ namespace Quantum {
             PopupAnimationTime = 0;
             enemy->IsDead = true;
             enemy->IsActive = false;
+            enemy->SetDelayedRespawn();
 
             f.Unsafe.GetPointer<Interactable>(piranhaPlantEntity)->ColliderDisabled = true;
 

--- a/Assets/QuantumUser/Simulation/NSMB/Gamemode/StarChasersGamemode.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Gamemode/StarChasersGamemode.cs
@@ -125,7 +125,7 @@ namespace Quantum {
                 FP magni = (starBand + normStarAvg * starsToWin) / starsToWin;
                 bonus = item.AboveAverageBonus * FPMath.Log(FPMath.Abs(itemRank) + 1, FP.E) * magni;
             } else {
-                FP magni = (starsAvg + starsFirstPlace * FP._5) / starsToWin;
+                FP magni = (starsAvg + starsFirstPlace * FP._0_50) / starsToWin;
                 bonus = item.BelowAverageBonus * FPMath.Log(FPMath.Abs(itemRank) + 1, FP.E) * magni;
             }
             return FPMath.Max(0, item.SpawnChance + bonus);

--- a/Assets/Resources/Particle/Respawn.prefab
+++ b/Assets/Resources/Particle/Respawn.prefab
@@ -270,7 +270,7 @@ ParticleSystem:
       serializedVersion: 2
       minMaxState: 0
       minColor: {r: 1, g: 1, b: 1, a: 1}
-      maxColor: {r: 1, g: 1, b: 1, a: 1}
+      maxColor: {r: 165, g: 42, b: 42, a: 1}
       maxGradient:
         serializedVersion: 2
         key0: {r: 1, g: 1, b: 1, a: 1}
@@ -4805,7 +4805,7 @@ ParticleSystem:
     vectorLabel1_3: W
 --- !u!199 &5412334486319678067
 ParticleSystemRenderer:
-  serializedVersion: 6
+  serializedVersion: 7
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -4824,6 +4824,8 @@ ParticleSystemRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -4845,9 +4847,11 @@ ParticleSystemRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: -755315459
   m_SortingLayer: 1
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_RenderMode: 0
   m_MeshDistribution: 0
   m_SortMode: 0
@@ -4879,7 +4883,6 @@ ParticleSystemRenderer:
   m_MeshWeighting1: 1
   m_MeshWeighting2: 1
   m_MeshWeighting3: 1
-  m_MaskInteraction: 0
 --- !u!1 &7940514336992764709
 GameObject:
   m_ObjectHideFlags: 0
@@ -5103,7 +5106,7 @@ ParticleSystem:
       serializedVersion: 2
       minMaxState: 0
       minColor: {r: 1, g: 1, b: 1, a: 1}
-      maxColor: {r: 1, g: 1, b: 1, a: 1}
+      maxColor: {r: 165, g: 42, b: 42, a: 1}
       maxGradient:
         serializedVersion: 2
         key0: {r: 1, g: 1, b: 1, a: 1}
@@ -9696,7 +9699,7 @@ ParticleSystem:
     vectorLabel1_3: W
 --- !u!199 &7653967124022579032
 ParticleSystemRenderer:
-  serializedVersion: 6
+  serializedVersion: 7
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -9715,6 +9718,8 @@ ParticleSystemRenderer:
   m_RayTracingAccelStructBuildFlagsOverride: 0
   m_RayTracingAccelStructBuildFlags: 1
   m_SmallMeshCulling: 1
+  m_ForceMeshLod: -1
+  m_MeshLodSelectionBias: 0
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -9736,9 +9741,11 @@ ParticleSystemRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
+  m_GlobalIlluminationMeshLod: 0
   m_SortingLayerID: -755315459
   m_SortingLayer: 1
   m_SortingOrder: 0
+  m_MaskInteraction: 0
   m_RenderMode: 0
   m_MeshDistribution: 0
   m_SortMode: 0
@@ -9770,4 +9777,3 @@ ParticleSystemRenderer:
   m_MeshWeighting1: 1
   m_MeshWeighting2: 1
   m_MeshWeighting3: 1
-  m_MaskInteraction: 0

--- a/Assets/Scripts/Entity/Enemy/BobombAnimator.cs
+++ b/Assets/Scripts/Entity/Enemy/BobombAnimator.cs
@@ -77,7 +77,8 @@ namespace NSMB.Entities.Enemies {
             }
 
             // Bodge...
-            if (!enemy->IsAlive) {
+            // Fuck whoever wrote this, they REALLY wanted to mess UP my respawn code >:(
+            if (!enemy->IsAlive && enemy->RespawnTimer > enemy->RespawnSparklesTimer + 1) {
                 sfx.Stop();
             }
 

--- a/Assets/Scripts/Entity/Enemy/BobombAnimator.cs
+++ b/Assets/Scripts/Entity/Enemy/BobombAnimator.cs
@@ -18,9 +18,11 @@ namespace NSMB.Entities.Enemies {
         [SerializeField] private SpriteRenderer sRenderer;
         [SerializeField] private Animator animator;
         [SerializeField] private GameObject explosionPrefab;
+        [SerializeField] private GameObject respawnParticle;
 
         //---Private Variables
         private MaterialPropertyBlock mpb;
+        private GameObject activeRespawnParticle;
 
         public void OnValidate() {
             this.SetIfNull(ref sRenderer, UnityExtensions.GetComponentType.Children);
@@ -32,6 +34,7 @@ namespace NSMB.Entities.Enemies {
             QuantumEvent.Subscribe<EventBobombExploded>(this, OnBobombExploded, FilterOutReplayFastForward);
             QuantumEvent.Subscribe<EventBobombLit>(this, OnBobombLit, FilterOutReplayFastForward);
             QuantumEvent.Subscribe<EventPlayComboSound>(this, OnPlayComboSound, FilterOutReplayFastForward);
+            QuantumEvent.Subscribe<EventEnemyRespawnSparkles>(this, OnEnemyRespawnSparkles, FilterOutReplayFastForward);
             QuantumEvent.Subscribe<EventGameEnded>(this, OnGameEnded);
         }
 
@@ -122,6 +125,22 @@ namespace NSMB.Entities.Enemies {
             }
 
             sfx.Play(SoundEffect.Enemy_Bobomb_Fuse);
+        }
+
+        private void OnEnemyRespawnSparkles(EventEnemyRespawnSparkles e) {
+            if (e.Entity != EntityRef) {
+                return;
+            }
+            Frame f = PredictedFrame;
+
+            var enemy = f.Unsafe.GetPointer<Enemy>(EntityRef);
+            activeRespawnParticle = Instantiate(respawnParticle, enemy->Spawnpoint.ToUnityVector3() + (Vector3.up * 0.25f), Quaternion.identity);
+            foreach (ParticleSystem particle in activeRespawnParticle.GetComponentsInChildren<ParticleSystem>()) {
+                var main = particle.main;
+                main.startColor = Color.darkGray;
+            }
+
+            sfx.PlayOneShot(SoundEffect.Player_Sound_Respawn);
         }
     }
 }

--- a/Assets/Scripts/Entity/Enemy/BooAnimator.cs
+++ b/Assets/Scripts/Entity/Enemy/BooAnimator.cs
@@ -31,6 +31,9 @@ namespace NSMB.Entities.Enemies {
         public void Start() {
             QuantumEvent.Subscribe<EventBooBecomeActive>(this, OnBooBecameActive, FilterOutReplayFastForward);
             QuantumEvent.Subscribe<EventPlayComboSound>(this, OnPlayComboSound, FilterOutReplayFastForward);
+            QuantumEvent.Subscribe<EventEnemyRespawnSparkles>(this, OnEnemyRespawnSparkles, FilterOutReplayFastForward);
+            QuantumEvent.Subscribe<EventEnemyAfterDelayedRespawn>(this, OnEnemyAfterDelayedRespawn, FilterOutReplayFastForward);
+
         }
 
         public override void OnUpdateView() {
@@ -70,6 +73,33 @@ namespace NSMB.Entities.Enemies {
             }
 
             sfx.PlayOneShot(QuantumViewUtils.GetComboSoundEffect(e.Combo));
+        }
+
+        private unsafe void OnEnemyRespawnSparkles(EventEnemyRespawnSparkles e) {
+            if (e.Entity != EntityRef) {
+                return;
+            }
+
+            Frame f = PredictedFrame;
+
+            var enemy = f.Unsafe.GetPointer<Enemy>(EntityRef);
+
+            Instantiate(Enums.PrefabParticle.Enemy_Puff.GetGameObject(), enemy->Spawnpoint.ToUnityVector3() + (Vector3.up * 0.25f), Quaternion.identity);
+
+            // play boo laugh as warning
+            sfx.PlayOneShot(SoundEffect.Enemy_Boo_Laugh);
+        }
+
+        private unsafe void OnEnemyAfterDelayedRespawn(EventEnemyAfterDelayedRespawn e) {
+            if (e.Entity != EntityRef) {
+                return;
+            }
+
+            Frame f = PredictedFrame;
+
+            var enemy = f.Unsafe.GetPointer<Enemy>(EntityRef);
+
+            Instantiate(Enums.PrefabParticle.Enemy_Puff.GetGameObject(), enemy->Spawnpoint.ToUnityVector3() + (Vector3.up * 0.25f), Quaternion.identity);
         }
     }
 }

--- a/Assets/Scripts/Entity/Enemy/GoombaAnimator.cs
+++ b/Assets/Scripts/Entity/Enemy/GoombaAnimator.cs
@@ -29,6 +29,8 @@ namespace NSMB.Entities.Enemies {
             QuantumEvent.Subscribe<EventEnemyKilled>(this, OnEnemyKilled, FilterOutReplayFastForward);
             QuantumEvent.Subscribe<EventPlayComboSound>(this, OnPlayComboSound, FilterOutReplayFastForward);
             QuantumEvent.Subscribe<EventEnemyRespawnSparkles>(this, OnEnemyRespawnSparkles, FilterOutReplayFastForward);
+            QuantumEvent.Subscribe<EventEnemyAfterDelayedRespawn>(this, OnEnemyAfterDelayedRespawn, FilterOutReplayFastForward);
+
         }
 
         public override unsafe void OnUpdateView() {
@@ -82,6 +84,17 @@ namespace NSMB.Entities.Enemies {
             }
         }
         
+        private void OnEnemyAfterDelayedRespawn(EventEnemyAfterDelayedRespawn e) {
+            if (e.Entity != EntityRef) {
+                return;
+            }
+            Frame f = PredictedFrame;
+
+            var enemy = f.Unsafe.GetPointer<Enemy>(EntityRef);
+
+            Instantiate(Enums.PrefabParticle.Enemy_Puff.GetGameObject(), enemy->Spawnpoint.ToUnityVector3() + (Vector3.up * 0.25f), Quaternion.identity);
+        }
+
         private void OnEnemyRespawnSparkles(EventEnemyRespawnSparkles e) {
             if (e.Entity != EntityRef) {
                 return;

--- a/Assets/Scripts/Entity/Enemy/GoombaAnimator.cs
+++ b/Assets/Scripts/Entity/Enemy/GoombaAnimator.cs
@@ -13,8 +13,11 @@ namespace NSMB.Entities.Enemies {
         [SerializeField] private SpriteRenderer sRenderer;
         [SerializeField] private Sprite deadSprite;
         [SerializeField] private GameObject specialKillParticle;
+        [SerializeField] private GameObject respawnParticle;
         [SerializeField] private LegacyAnimateSpriteRenderer legacyAnimation;
         [SerializeField] private SoundEffectPlayer sfx;
+
+        private GameObject activeRespawnParticle;
 
         public void OnValidate() {
             this.SetIfNull(ref sRenderer, UnityExtensions.GetComponentType.Children);
@@ -25,6 +28,7 @@ namespace NSMB.Entities.Enemies {
         public void Start() {
             QuantumEvent.Subscribe<EventEnemyKilled>(this, OnEnemyKilled, FilterOutReplayFastForward);
             QuantumEvent.Subscribe<EventPlayComboSound>(this, OnPlayComboSound, FilterOutReplayFastForward);
+            QuantumEvent.Subscribe<EventEnemyRespawnSparkles>(this, OnEnemyRespawnSparkles, FilterOutReplayFastForward);
         }
 
         public override unsafe void OnUpdateView() {
@@ -76,6 +80,22 @@ namespace NSMB.Entities.Enemies {
             if (e.KillReason == EnemyKillReason.Groundpounded) {
                 Instantiate(specialKillParticle, transform.position + Vector3.up * 0.2f, Quaternion.identity);
             }
+        }
+        
+        private void OnEnemyRespawnSparkles(EventEnemyRespawnSparkles e) {
+            if (e.Entity != EntityRef) {
+                return;
+            }
+            Frame f = PredictedFrame;
+
+            var enemy = f.Unsafe.GetPointer<Enemy>(EntityRef);
+            activeRespawnParticle = Instantiate(respawnParticle, enemy->Spawnpoint.ToUnityVector3() + (Vector3.up * 0.25f), Quaternion.identity);
+            foreach (ParticleSystem particle in activeRespawnParticle.GetComponentsInChildren<ParticleSystem>()) {
+                var main = particle.main;
+                main.startColor = Color.saddleBrown;
+            }
+
+            sfx.PlayOneShot(SoundEffect.Player_Sound_Respawn);
         }
     }
 }

--- a/Assets/Scripts/Entity/Enemy/GoombaAnimator.cs
+++ b/Assets/Scripts/Entity/Enemy/GoombaAnimator.cs
@@ -30,7 +30,7 @@ namespace NSMB.Entities.Enemies {
             QuantumEvent.Subscribe<EventPlayComboSound>(this, OnPlayComboSound, FilterOutReplayFastForward);
             QuantumEvent.Subscribe<EventEnemyRespawnSparkles>(this, OnEnemyRespawnSparkles, FilterOutReplayFastForward);
             QuantumEvent.Subscribe<EventEnemyAfterDelayedRespawn>(this, OnEnemyAfterDelayedRespawn, FilterOutReplayFastForward);
-
+            QuantumEvent.Subscribe<EventEnemySufferedOffscreen>(this, OnEnemySufferedOffscreen, FilterOutReplayFastForward);
         }
 
         public override unsafe void OnUpdateView() {
@@ -109,6 +109,18 @@ namespace NSMB.Entities.Enemies {
             }
 
             sfx.PlayOneShot(SoundEffect.Player_Sound_Respawn);
+        }
+
+        private void OnEnemySufferedOffscreen(EventEnemySufferedOffscreen e) {
+            if (e.Entity != EntityRef) {
+                return;
+            }
+
+            Frame f = PredictedFrame;
+
+            var enemy = f.Unsafe.GetPointer<Enemy>(EntityRef);
+
+            Instantiate(Enums.PrefabParticle.Enemy_Puff.GetGameObject(), enemy->Spawnpoint.ToUnityVector3() + (Vector3.up * 0.25f), Quaternion.identity);
         }
     }
 }

--- a/Assets/Scripts/Entity/Enemy/KoopaAnimator.cs
+++ b/Assets/Scripts/Entity/Enemy/KoopaAnimator.cs
@@ -20,9 +20,12 @@ namespace NSMB.Entities.Enemies {
         [SerializeField] private SoundEffectPlayer sfx;
         [SerializeField] private SpriteRenderer sRenderer;
         [SerializeField] private Transform rotation;
+        [SerializeField] private GameObject respawnParticle;
+        [SerializeField] private Color respawnColor;
         [SerializeField] private bool mirrorSprite, dontFlip;
 
         //---Private Variables
+        private GameObject activeRespawnParticle;
         private float dampVelocity;
         private bool facingRight;
 
@@ -35,6 +38,8 @@ namespace NSMB.Entities.Enemies {
         public void Start() {
             QuantumEvent.Subscribe<EventPlayComboSound>(this, OnPlayComboSound, FilterOutReplayFastForward, onlyIfActiveAndEnabled: true);
             QuantumEvent.Subscribe<EventPlayBumpSound>(this, OnPlayBumpSound, FilterOutReplayFastForward, onlyIfActiveAndEnabled: true);
+            QuantumEvent.Subscribe<EventEnemyRespawnSparkles>(this, OnEnemyRespawnSparkles, FilterOutReplayFastForward);
+            QuantumEvent.Subscribe<EventEnemyAfterDelayedRespawn>(this, OnEnemyAfterDelayedRespawn, FilterOutReplayFastForward);
         }
 
         public override unsafe void OnUpdateView() {
@@ -118,6 +123,33 @@ namespace NSMB.Entities.Enemies {
             }
 
             sfx.PlayOneShot(QuantumViewUtils.GetComboSoundEffect(e.Combo));
+        }
+
+        private unsafe void OnEnemyAfterDelayedRespawn(EventEnemyAfterDelayedRespawn e) {
+            if (e.Entity != EntityRef) {
+                return;
+            }
+            Frame f = PredictedFrame;
+
+            var enemy = f.Unsafe.GetPointer<Enemy>(EntityRef);
+
+            Instantiate(Enums.PrefabParticle.Enemy_Puff.GetGameObject(), enemy->Spawnpoint.ToUnityVector3() + (Vector3.up * 0.25f), Quaternion.identity);
+        }
+
+        private unsafe void OnEnemyRespawnSparkles(EventEnemyRespawnSparkles e) {
+            if (e.Entity != EntityRef) {
+                return;
+            }
+            Frame f = PredictedFrame;
+
+            var enemy = f.Unsafe.GetPointer<Enemy>(EntityRef);
+            activeRespawnParticle = Instantiate(respawnParticle, enemy->Spawnpoint.ToUnityVector3() + (Vector3.up * 0.25f), Quaternion.identity);
+            foreach (ParticleSystem particle in activeRespawnParticle.GetComponentsInChildren<ParticleSystem>()) {
+                var main = particle.main;
+                main.startColor = respawnColor;
+            }
+
+            sfx.PlayOneShot(SoundEffect.Player_Sound_Respawn);
         }
     }
 }

--- a/Assets/Scripts/Entity/MiscParticles.cs
+++ b/Assets/Scripts/Entity/MiscParticles.cs
@@ -15,6 +15,7 @@ public class MiscParticles : QuantumSceneViewComponent {
         QuantumEvent.Subscribe<EventProjectileDestroyed>(this, OnProjectileDestroyed, FilterOutReplayFastForward);
         QuantumEvent.Subscribe<EventCollectableDespawned>(this, OnCollectableDespawned, FilterOutReplayFastForward);
         QuantumEvent.Subscribe<EventEnemyKicked>(this, OnEnemyKicked, FilterOutReplayFastForward);
+        QuantumEvent.Subscribe<EventEnemySufferedOffscreen>(this, OnEnemySufferedOffscreen, FilterOutReplayFastForward);
         Instance = this;
     }
 
@@ -53,6 +54,10 @@ public class MiscParticles : QuantumSceneViewComponent {
                 view.transform.position + (Vector3.back * 5) + (Vector3.up * 0.1f),
                 Quaternion.identity);
         }
+    }
+
+    private unsafe void OnEnemySufferedOffscreen(EventEnemySufferedOffscreen e) {
+        Play(ParticleEffect.Puff, e.Position.ToUnityVector3());
     }
 
     [Serializable]


### PR DESCRIPTION
This reworks how the enemy system works to make it a little closer to how it works in the original game whilst being adjusted for Mario vs. Luigi Online. Enemies will now respawn shortly after being killed (being 6 seconds for most, 3 seconds for bob-ombs after they explode and 10 seconds for the Blue Shell Koopa), despawn if they GO off screen, face the closest player when spawning and are no longer tied to collecting a star.

## WARNING
This branch also includes minor adjustments to the item spawn rates (including fixing the FP._5 bug) which should have the Mega Mushroom and Starman spawn more frequently as well as lowering the spawnrate for blue shell.

https://github.com/user-attachments/assets/dcd9fa71-64d0-4358-82f9-6aa48eeca31c

