### PR TITLE
Big Star Accuracy

### DIFF
--- a/Assets/Animations/Player/Mario/LargeMario.controller
+++ b/Assets/Animations/Player/Mario/LargeMario.controller
@@ -8179,7 +8179,7 @@ AnimatorState:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: walljump
-  m_Speed: 1
+  m_Speed: 0.375
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: 3966724826765006966}

--- a/Assets/QuantumUser/Resources/EntityPrototypes/BigStar.prefab
+++ b/Assets/QuantumUser/Resources/EntityPrototypes/BigStar.prefab
@@ -322,7 +322,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   pulseAmount: 0.05
   pulseSpeed: 16
-  rotationSpeed: 6
+  rotationSpeed: 3
   blinkingSpeed: 0.25
   graphicTransform: {fileID: 7308630834410186342}
   particles: {fileID: 5237286551399780066}
@@ -369,7 +369,7 @@ MonoBehaviour:
     Speed:
       RawValue: 98304
     BounceForce:
-      RawValue: 491520
+      RawValue: 360448
 --- !u!114 &5641718087526033968
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Makes the Big Star's physics accurate to the original by making the rotation slower, and the bounce weaker.