### PR TITLE
I made this PR because Windows10V is lazy

### DIFF
--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayerPhysicsInfo.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayerPhysicsInfo.cs
@@ -38,6 +38,7 @@ public class MarioPlayerPhysicsInfo : AssetObject {
     // --- Hitboxes
     public FP SmallHitboxHeight = FF(0.42f);
     public FP LargeHitboxHeight = FF(0.82f);
+    public FP BlueShellHitboxHeight = FF(0.42f);
 
     // --- Jumping
     public byte JumpBufferFrames = 12;

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayerSystem.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayerSystem.cs
@@ -1768,9 +1768,12 @@ namespace Quantum {
             var collider = filter.PhysicsCollider;
 
             FP newHeight;
-            bool crouchHitbox = mario->CurrentPowerupState >= PowerupState.Mushroom && mario->CurrentPowerupState != PowerupState.MegaMushroom && !f.Exists(mario->CurrentPipe) && ((mario->IsCrouching && !mario->IsGroundpounding) || mario->IsInShell || mario->IsSliding);
+            bool blueShellHitbox = mario->IsCrouchedInShell || mario->IsInShell;
+            bool crouchHitbox = mario->CurrentPowerupState >= PowerupState.Mushroom && mario->CurrentPowerupState != PowerupState.MegaMushroom && !f.Exists(mario->CurrentPipe) && ((mario->IsCrouching && !mario->IsCrouchedInShell && !mario->IsGroundpounding) || mario->IsSliding);
             bool smallHitbox = mario->CurrentPowerupState != PowerupState.MegaMushroom && ((mario->IsStarmanInvincible && !physicsObject->IsTouchingGround && !crouchHitbox && !mario->IsSliding && !mario->IsSpinnerFlying && !mario->IsPropellerFlying) || mario->IsGroundpounding);
-            if (mario->CurrentPowerupState <= PowerupState.MiniMushroom || smallHitbox) {
+            if (blueShellHitbox) {
+                newHeight = physics.BlueShellHitboxHeight;
+            } else if (mario->CurrentPowerupState <= PowerupState.MiniMushroom || smallHitbox) {
                 newHeight = physics.SmallHitboxHeight;
             } else {
                 newHeight = physics.LargeHitboxHeight;


### PR DESCRIPTION
all this does is add a BlueShellHitboxHeight to MarioPlayerPhysicsInfo and a calculation for the BlueShellHitboxHeight in MarioPlayerSystem's HandleHitbox (adjusting the code to accommodate for the new Blue Shell hitbox).

676767676767 uh ohhhh here's comes the rizzler uwwwwwwooooooooah skibidi ohio gyatt sigma. Bro is fr fr onGOd with not puttin da fries in da bag and makin dis peepee pr smh smh.