### PR TITLE
Longer Enemies Freeze Time

### DIFF
--- a/Assets/QuantumUser/Resources/EntityPrototypes/Enemy/BlueKoopa.prefab
+++ b/Assets/QuantumUser/Resources/EntityPrototypes/Enemy/BlueKoopa.prefab
@@ -94,6 +94,11 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 22100000, guid: 8df73f9409b06d04190e8538ddfd3727,
         type: 2}
+    - target: {fileID: 4870734189259043644, guid: 8cf8f49ac0882ed44953ea53ff901f11,
+        type: 3}
+      propertyPath: Prototype.AutoBreakFrames
+      value: 480
+      objectReference: {fileID: 0}
     - target: {fileID: 5882114383898416491, guid: 8cf8f49ac0882ed44953ea53ff901f11,
         type: 3}
       propertyPath: respawnColor.a

--- a/Assets/QuantumUser/Resources/EntityPrototypes/Enemy/Bobomb.prefab
+++ b/Assets/QuantumUser/Resources/EntityPrototypes/Enemy/Bobomb.prefab
@@ -717,7 +717,7 @@ MonoBehaviour:
         RawValue: 42598
       Y:
         RawValue: 42598
-    AutoBreakFrames: 180
+    AutoBreakFrames: 480
     AutoBreakGrabAdditionalFrames: 0
     AutoBreakWhileHeld:
       Value: 0

--- a/Assets/QuantumUser/Resources/EntityPrototypes/Enemy/Goomba.prefab
+++ b/Assets/QuantumUser/Resources/EntityPrototypes/Enemy/Goomba.prefab
@@ -710,7 +710,7 @@ MonoBehaviour:
         RawValue: 42598
       Y:
         RawValue: 42598
-    AutoBreakFrames: 180
+    AutoBreakFrames: 480
     AutoBreakGrabAdditionalFrames: 0
     AutoBreakWhileHeld:
       Value: 0

--- a/Assets/QuantumUser/Resources/EntityPrototypes/Enemy/Koopa.prefab
+++ b/Assets/QuantumUser/Resources/EntityPrototypes/Enemy/Koopa.prefab
@@ -735,7 +735,7 @@ MonoBehaviour:
         RawValue: 0
       Y:
         RawValue: 0
-    AutoBreakFrames: 180
+    AutoBreakFrames: 480
     AutoBreakGrabAdditionalFrames: 0
     AutoBreakWhileHeld:
       Value: 0

--- a/Assets/QuantumUser/Resources/EntityPrototypes/Enemy/PiranhaPlant.prefab
+++ b/Assets/QuantumUser/Resources/EntityPrototypes/Enemy/PiranhaPlant.prefab
@@ -637,7 +637,7 @@ MonoBehaviour:
         RawValue: 49152
       Y:
         RawValue: 88474
-    AutoBreakFrames: 180
+    AutoBreakFrames: 480
     AutoBreakGrabAdditionalFrames: 0
     AutoBreakWhileHeld:
       Value: 0

--- a/Assets/QuantumUser/Resources/EntityPrototypes/Enemy/Spiny.prefab
+++ b/Assets/QuantumUser/Resources/EntityPrototypes/Enemy/Spiny.prefab
@@ -621,7 +621,7 @@ MonoBehaviour:
         RawValue: 0
       Y:
         RawValue: 0
-    AutoBreakFrames: 180
+    AutoBreakFrames: 480
     AutoBreakGrabAdditionalFrames: 0
     AutoBreakWhileHeld:
       Value: 0

--- a/Assets/QuantumUser/Simulation/Generated/Quantum.CodeGen.Core.cs
+++ b/Assets/QuantumUser/Simulation/Generated/Quantum.CodeGen.Core.cs
@@ -2174,23 +2174,23 @@ namespace Quantum {
   }
   [StructLayout(LayoutKind.Explicit)]
   public unsafe partial struct Freezable : Quantum.IComponent {
-    public const Int32 SIZE = 56;
+    public const Int32 SIZE = 64;
     public const Int32 ALIGNMENT = 8;
-    [FieldOffset(24)]
+    [FieldOffset(32)]
     public FPVector2 IceBlockSize;
-    [FieldOffset(0)]
-    public Byte AutoBreakFrames;
-    [FieldOffset(1)]
-    public Byte AutoBreakGrabAdditionalFrames;
     [FieldOffset(4)]
-    public QBoolean AutoBreakWhileHeld;
-    [FieldOffset(40)]
-    public FPVector2 Offset;
+    public Int32 AutoBreakFrames;
+    [FieldOffset(0)]
+    public Byte AutoBreakGrabAdditionalFrames;
     [FieldOffset(8)]
-    public QBoolean IsCarryable;
+    public QBoolean AutoBreakWhileHeld;
+    [FieldOffset(48)]
+    public FPVector2 Offset;
     [FieldOffset(12)]
-    public QBoolean IsFlying;
+    public QBoolean IsCarryable;
     [FieldOffset(16)]
+    public QBoolean IsFlying;
+    [FieldOffset(24)]
     [ExcludeFromPrototype()]
     public EntityRef FrozenCubeEntity;
     public override readonly Int32 GetHashCode() {
@@ -2209,8 +2209,8 @@ namespace Quantum {
     }
     public static void Serialize(void* ptr, FrameSerializer serializer) {
         var p = (Freezable*)ptr;
-        serializer.Stream.Serialize(&p->AutoBreakFrames);
         serializer.Stream.Serialize(&p->AutoBreakGrabAdditionalFrames);
+        serializer.Stream.Serialize(&p->AutoBreakFrames);
         QBoolean.Serialize(&p->AutoBreakWhileHeld, serializer);
         QBoolean.Serialize(&p->IsCarryable, serializer);
         QBoolean.Serialize(&p->IsFlying, serializer);
@@ -2350,10 +2350,10 @@ namespace Quantum {
     [FieldOffset(8)]
     [ExcludeFromPrototype()]
     public QBoolean FacingRight;
-    [FieldOffset(0)]
-    [ExcludeFromPrototype()]
-    public Byte AutoBreakFrames;
     [FieldOffset(4)]
+    [ExcludeFromPrototype()]
+    public Int32 AutoBreakFrames;
+    [FieldOffset(0)]
     [ExcludeFromPrototype()]
     public LiquidType InLiquidType;
     public override readonly Int32 GetHashCode() {
@@ -2373,8 +2373,8 @@ namespace Quantum {
     }
     public static void Serialize(void* ptr, FrameSerializer serializer) {
         var p = (IceBlock*)ptr;
-        serializer.Stream.Serialize(&p->AutoBreakFrames);
         serializer.Stream.Serialize((byte*)&p->InLiquidType);
+        serializer.Stream.Serialize(&p->AutoBreakFrames);
         QBoolean.Serialize(&p->FacingRight, serializer);
         QBoolean.Serialize(&p->IsFlying, serializer);
         QBoolean.Serialize(&p->IsSliding, serializer);

--- a/Assets/QuantumUser/Simulation/Generated/Quantum.CodeGen.Prototypes.cs
+++ b/Assets/QuantumUser/Simulation/Generated/Quantum.CodeGen.Prototypes.cs
@@ -394,7 +394,7 @@ namespace Quantum.Prototypes {
   [Quantum.Prototypes.Prototype(typeof(Quantum.Freezable))]
   public unsafe partial class FreezablePrototype : ComponentPrototype<Quantum.Freezable> {
     public FPVector2 IceBlockSize;
-    public Byte AutoBreakFrames;
+    public Int32 AutoBreakFrames;
     public Byte AutoBreakGrabAdditionalFrames;
     public QBoolean AutoBreakWhileHeld;
     public FPVector2 Offset;

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Freezable/Freezable.qtn
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Freezable/Freezable.qtn
@@ -1,6 +1,6 @@
 component Freezable {
 	FPVector2 IceBlockSize;
-	byte AutoBreakFrames;
+	int AutoBreakFrames;
 	byte AutoBreakGrabAdditionalFrames;
 	bool AutoBreakWhileHeld;
 	FPVector2 Offset;

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/IceBlock/IceBlock.qtn
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/IceBlock/IceBlock.qtn
@@ -9,7 +9,7 @@ component IceBlock {
 	[ExcludeFromPrototype] bool IsFlying;
 	[ExcludeFromPrototype] bool IsSliding;
 	[ExcludeFromPrototype] bool FacingRight;
-	[ExcludeFromPrototype] byte AutoBreakFrames;
+	[ExcludeFromPrototype] int AutoBreakFrames;
 	[ExcludeFromPrototype] LiquidType InLiquidType;
 }
 

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/IceBlock/IceBlockSystem.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/IceBlock/IceBlockSystem.cs
@@ -164,7 +164,7 @@ namespace Quantum {
                     holdable2->Pickup(f, iceBlockEntity, marioEntity);
 
                     // Don't allow overflow
-                    iceBlock->AutoBreakFrames = (byte) FPMath.Clamp(iceBlock->AutoBreakFrames + child->AutoBreakGrabAdditionalFrames, 0, byte.MaxValue);
+                    iceBlock->AutoBreakFrames = FPMath.Clamp(iceBlock->AutoBreakFrames + child->AutoBreakGrabAdditionalFrames, 0, int.MaxValue);
                 }
             }
             return false;


### PR DESCRIPTION
This is a small accuracy to NSMBWii where enemies (goombas, koopas, etc) have a longer freeze time (3 seconds -> 8 seconds).
This likely barely affects anything in-game, but if it does, then i'd say it's positive, cuz you have more time to use them as weapons/shield.