### PR TITLE
Bring back the "nice" comment next to the 69th sound effect

### DIFF
--- a/Assets/QuantumUser/Simulation/NSMB/Enums/SoundEffect.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Enums/SoundEffect.cs
@@ -114,7 +114,7 @@ public enum SoundEffect : byte {
     //World Elements
     World_Block_Break = 67,
     World_Block_Bump = 68,
-    World_Block_Powerup = 69,
+    World_Block_Powerup = 69, // Nice
     World_Block_Powerup_Mega = 99,
     World_Coin_Collect = 70,
     World_Coin_Drop = 91,


### PR DESCRIPTION
It was in 1.7 but got removed in 2.0, which slightly makes the game unplayable, so I fixed it.