### PR TITLE
gg ez

### DIFF
--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Koopa/KoopaSystem.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Koopa/KoopaSystem.cs
@@ -390,7 +390,7 @@ namespace Quantum {
             }
 
             if (koopa->IsInShell && koopa->IsKicked) {
-                IceBlockSystem.Destroy(f, iceBlockEntity, IceBlockBreakReason.Other, koopaEntity);
+                IceBlockSystem.Destroy(f, iceBlockEntity, IceBlockBreakReason.Shell, koopaEntity);
             }
             return false;
         }

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/IceBlock/IceBlockBreakReason.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/IceBlock/IceBlockBreakReason.cs
@@ -5,5 +5,7 @@ public enum IceBlockBreakReason : byte {
     BlockBump,
     HitWall,
     InvincibleMario,
+    Shell,
+    Explosion,
     Other,
 }

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/IceBlock/IceBlockSystem.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/IceBlock/IceBlockSystem.cs
@@ -135,7 +135,7 @@ namespace Quantum {
                 // Side
                 bool rightContact = contact.Normal.X > 0;
                 if (mario->IsInShell) {
-                    Destroy(f, iceBlockEntity, IceBlockBreakReason.HitWall, marioEntity);
+                    Destroy(f, iceBlockEntity, IceBlockBreakReason.Shell, marioEntity);
                     return false;
                 } else if (iceBlock->IsSliding && iceBlock->FacingRight == rightContact) {
                     var holdable = f.Unsafe.GetPointer<Holdable>(iceBlockEntity);
@@ -233,7 +233,7 @@ namespace Quantum {
 
         public void OnBobombExplodeEntity(Frame f, EntityRef bobomb, EntityRef entity) {
             if (f.Has<IceBlock>(entity)) {
-                Destroy(f, entity, IceBlockBreakReason.None, bobomb);
+                Destroy(f, entity, IceBlockBreakReason.Explosion, bobomb);
             }
         }
 

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayerSystem.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayerSystem.cs
@@ -2884,6 +2884,8 @@ namespace Quantum {
                 mario->DamageInvincibilityFrames = Constants.DamageInvincibilityFrames;
                 break;
 
+            case IceBlockBreakReason.Shell:
+            case IceBlockBreakReason.Explosion:
             case IceBlockBreakReason.InvincibleMario:
                 // Damage, i-frames.
                 strength = KnockbackStrength.Groundpound;


### PR DESCRIPTION
#495

makes shells and bobomb explosions deal damage to the player in an ice block instead of just breaking them harmlessly, fixing a bit of a flaw with the ice block being that it makes the victim invincible to everything other than throws and invincible Mario.