### PR TITLE
Make boos ignore invincible players

### DIFF
--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Boo/BooSystem.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Boo/BooSystem.cs
@@ -106,6 +106,12 @@ namespace Quantum {
                 if (mario->IsDead) {
                     continue;
                 }
+                if (mario->IsStarmanInvincible || mario->CurrentPowerupState == PowerupState.MegaMushroom) {
+                    continue;
+                }
+                if (mario->IsCrouchingInBlueShell) {
+                    continue;
+                }
 
                 FP newDistance = QuantumUtils.WrappedDistance(stage, booPosition, marioTransform->Position);
 


### PR DESCRIPTION
And sold, I'll be taking the money for #505 

I am not home so I cannot test this. This PR makes Boos not GO towards players who are starman invincible or crouched in Blue Shell. I was thinking about attack mode blue shell but I think that's too much.