### PR TITLE
OwO

### DIFF
--- a/Assets/QuantumUser/Simulation/Helpers/StartDisabledLaterSystemGroup.cs
+++ b/Assets/QuantumUser/Simulation/Helpers/StartDisabledLaterSystemGroup.cs
@@ -1,0 +1,8 @@
+namespace Quantum {
+    public class StartDisabledLaterSystemGroup : StartDisabledSystemGroup {
+
+        public StartDisabledLaterSystemGroup(params SystemBase[] children) : base(children) {
+
+        }
+    }
+}

--- a/Assets/QuantumUser/Simulation/Helpers/StartDisabledLaterSystemGroup.cs.meta
+++ b/Assets/QuantumUser/Simulation/Helpers/StartDisabledLaterSystemGroup.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7fc6ee8369e330c4684eac2a1cbe516e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Physics/PhysicsObjectSystem.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Physics/PhysicsObjectSystem.cs
@@ -133,6 +133,12 @@ namespace Quantum {
                 var transform = filter.Transform;
                 var entity = filter.Entity;
 
+                if (f.Global->GameState == GameState.Ended) {
+                    if (!f.Unsafe.TryGetPointer<MarioPlayer>(entity, out var mario)) { continue; }
+                    if (f.Global->WinningTeam == mario->GetTeam(f)) { continue; }
+                    if (!mario->IsDead || mario->IsRespawning) { continue; }
+                }
+
                 // bool canSnap = wasTouchingGround && physicsObject->Velocity.Y <= physicsObject->PreviousFrameVelocity.Y;
                 physicsObject->PreviousFrameVelocity = physicsObject->Velocity;
                 physicsObject->PreviousData = physicsObject->CurrentData;

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayer.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayer.cs
@@ -413,7 +413,7 @@ namespace Quantum {
 
             RespawnFrames = 78;
 
-            if (!IsValid(f)) {
+            if (!IsValid(f) && f.Global->GameState != GameState.Ended) {
                 f.Destroy(entity);
                 return;
             }

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayerSystem.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayerSystem.cs
@@ -36,6 +36,13 @@ namespace Quantum {
             var mario = filter.MarioPlayer;
             var player = mario->PlayerRef;
 
+            if (f.Global->GameState == GameState.Ended) {
+                if (f.Global->WinningTeam == mario->GetTeam(f) && mario->IsDead && !mario->IsRespawning) {
+                    HandleDeathAndRespawning(f, ref filter, stage);
+                    return;
+                }
+            }
+
             // Shuffle RNG.
             _ = mario->RNG.Next();
 
@@ -2051,23 +2058,25 @@ namespace Quantum {
 
             // Respawn timers
             // Actually respawning
-            if (mario->IsRespawning) {
-                if (QuantumUtils.Decrement(ref mario->RespawnFrames)) {
-                    mario->Respawn(f, entity);
-                    return false;
+            if (f.Global->GameState != GameState.Ended) {
+                if (mario->IsRespawning) {
+                    if (QuantumUtils.Decrement(ref mario->RespawnFrames)) {
+                        mario->Respawn(f, entity);
+                        return false;
+                    }
+                    return true;
                 }
-                return true;
-            }
 
-            // Waiting to prerespawn
-            if (QuantumUtils.Decrement(ref mario->PreRespawnFrames)) {
-                mario->PreRespawn(f, entity, stage);
-                f.Events.StartCameraFadeIn(entity);
-                return true;
+                // Waiting to prerespawn
+                if (QuantumUtils.Decrement(ref mario->PreRespawnFrames)) {
+                    mario->PreRespawn(f, entity, stage);
+                    f.Events.StartCameraFadeIn(entity);
+                    return true;
 
-            } else if (mario->PreRespawnFrames == 80) {
-                f.Events.StartCameraFadeOut(entity);
-                return true;
+                } else if (mario->PreRespawnFrames == 80 && f.Global->GameState != GameState.Ended) {
+                    f.Events.StartCameraFadeOut(entity);
+                    return true;
+                }
             }
 
             // Death up

--- a/Assets/QuantumUser/Simulation/NSMB/Logic/GameLogicSystem.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Logic/GameLogicSystem.cs
@@ -239,8 +239,8 @@ namespace Quantum {
                 return;
             }
 
-            f.Global->WinningTeam = 67;//winningTeam.GetValueOrDefault();
-            f.Global->HasWinner = true;// winningTeam.HasValue;
+            f.Global->WinningTeam = winningTeam.GetValueOrDefault();
+            f.Global->HasWinner = winningTeam.HasValue;
 
             f.Signals.OnGameEnding(winningTeam.GetValueOrDefault(), winningTeam.HasValue);
             f.Events.GameEnded(endedByHost, winningTeam.GetValueOrDefault(), winningTeam.HasValue);

--- a/Assets/QuantumUser/Simulation/NSMB/Logic/GameLogicSystem.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Logic/GameLogicSystem.cs
@@ -152,6 +152,7 @@ namespace Quantum {
                     // Respawn all players and enable systems
                     f.Global->StartFrame = f.Number;
                     f.SystemEnable<StartDisabledSystemGroup>();
+                    f.SystemEnable<StartDisabledLaterSystemGroup>();
 
                     foreach (var otherGamemode in f.Context.GetAllAssets<GamemodeAsset>()) {
                         otherGamemode.DisableGamemode(f);
@@ -213,6 +214,7 @@ namespace Quantum {
                     f.Global->GameState = GameState.PreGameRoom;
                     f.Events.GameStateChanged(GameState.PreGameRoom);
                     f.SystemDisable<StartDisabledSystemGroup>();
+                    f.SystemDisable<StartDisabledLaterSystemGroup>();
 
                     var gamemode = f.FindAsset(f.Global->Rules.Gamemode);
                     gamemode.DisableGamemode(f);
@@ -237,8 +239,8 @@ namespace Quantum {
                 return;
             }
 
-            f.Global->WinningTeam = winningTeam.GetValueOrDefault();
-            f.Global->HasWinner = winningTeam.HasValue;
+            f.Global->WinningTeam = 67;//winningTeam.GetValueOrDefault();
+            f.Global->HasWinner = true;// winningTeam.HasValue;
 
             f.Signals.OnGameEnding(winningTeam.GetValueOrDefault(), winningTeam.HasValue);
             f.Events.GameEnded(endedByHost, winningTeam.GetValueOrDefault(), winningTeam.HasValue);
@@ -254,6 +256,10 @@ namespace Quantum {
             f.Events.GameStateChanged(GameState.Ended);
             f.Global->GameStartFrames = (ushort) ((endedByHost ? Constants._3_50 : 21) * f.UpdateRate);
             f.SystemDisable<StartDisabledSystemGroup>();
+
+            if (!f.Global->HasWinner) {
+                f.SystemDisable<StartDisabledLaterSystemGroup>();
+            }
 
             var gamemode = f.FindAsset(f.Global->Rules.Gamemode);
             gamemode.DisableGamemode(f);

--- a/Assets/QuantumUser/Simulation/SystemSetup.User.cs
+++ b/Assets/QuantumUser/Simulation/SystemSetup.User.cs
@@ -24,7 +24,6 @@ namespace Quantum {
                     new MovingPlatformSystem(),
                     new EnemySystem(),
                     new InteractionSystem(),
-                    new PhysicsObjectSystem(),
                     new GoombaSystem(),
                     new KoopaSystem(),
                     new BobombSystem(),
@@ -38,7 +37,6 @@ namespace Quantum {
                     new PowerupSystem(),
                     new BlockBumpSystem(),
                     new BreakableObjectSystem(),
-                    new MarioPlayerSystem(),
                     new CoinSystem(),
                     new GoldBlockSystem(),
                     new WrappingObjectSystem(),
@@ -52,6 +50,12 @@ namespace Quantum {
                     new EnterablePipeSystem(),
                     new InvisibleBlockSystem()
                     // new BetterPhysicsObjectSystem()
+                )
+            );
+            systems.Add(
+                new StartDisabledLaterSystemGroup(
+                    new PhysicsObjectSystem(),
+                    new MarioPlayerSystem()
                 )
             );
             systems.Add(new StageSystem());

--- a/Assets/Scripts/Entity/Player/MarioPlayerAnimator.cs
+++ b/Assets/Scripts/Entity/Player/MarioPlayerAnimator.cs
@@ -142,7 +142,7 @@ namespace NSMB.Entities.Player {
         public Animator Animator => animator;
         public GameObject ModelRoot => modelRoot;
         public bool IsBelowDeathplane => transform.position.y <= ViewContext.Stage.StageWorldMin.Y.AsFloat;
-        
+
         //---Private Variables
         private Enums.PlayerEyeState eyeState;
         private Quaternion modelRotationTarget;
@@ -277,8 +277,11 @@ namespace NSMB.Entities.Player {
             }
 
             var mario = f.Unsafe.GetPointer<MarioPlayer>(EntityRef);
-
-            if (VerifiedFrame.Global->GameState >= GameState.Ended && !forceUpdate) {
+            
+            // stop animation if the match has ended
+            // and the match has no winner or if it does,
+            // player is winner or the player is not dead
+            if (VerifiedFrame.Global->GameState >= GameState.Ended && !forceUpdate && (!VerifiedFrame.Global->HasWinner || VerifiedFrame.Global->WinningTeam == mario->GetTeam(f) || !mario->IsDead)) {
                 animator.speed = 0;
                 modelRoot.SetActive(!mario->IsRespawning && !(mario->IsDead && IsBelowDeathplane));
                 SetParticleEmission(drillParticle, false);


### PR DESCRIPTION
Basically what this does is make players who are dead continue their death animation when the round is over.
We accomplish this by **NOT** disabling the `MarioPlayerSystem` and `PhysicsObjectSystem` (yes this is needed for Mario to move) the first time systems are disabled (unless the game ends with no winner, then we disable them). Only disabling them the second time systems are disabled (when it is time to return to the room) and adding some cases at the Handling methods.

If the round ends in a draw, the animations will **NOT** continue.
If the round is over and the player won they will not continue their animation, only **L**s like Windows10V continue their losing animation.




# did you know you can play as Wario?

https://github.com/user-attachments/assets/f01ba465-ce42-4c38-96a6-578dd8819005

