### PR TITLE
ICE nach Berlin Gesundbrunnen 20 Minuten später...

### DIFF
--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayer.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayer.cs
@@ -497,7 +497,7 @@ namespace Quantum {
             }
 
             var freezable = f.Unsafe.GetPointer<Freezable>(entity);
-            if ((!bypassDamageInvincibility && DamageInvincibilityFrames > 0) || f.Exists(CurrentPipe) || (freezable->IsFrozen(f) && freezable->FrozenCubeEntity != attacker) || IsDead || MegaMushroomStartFrames > 0 || MegaMushroomEndFrames > 0) {
+            if ((!bypassDamageInvincibility && DamageInvincibilityFrames > 0) || f.Exists(CurrentPipe) || IsDead || MegaMushroomStartFrames > 0 || MegaMushroomEndFrames > 0) {
                 return false;
             }
 


### PR DESCRIPTION
All this does is remove the "freezable" check from the DoKnockback code to fix frozen players that shatter not receiving knockback. This has no side effects so I'm a little unsure why this was added in the first place.