### PR TITLE
Blue Shell Attack Mode Star Fly Adjustment

### DIFF
--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayerSystem.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayerSystem.cs
@@ -2401,7 +2401,7 @@ namespace Quantum {
                         // transitions use this bool to make them lose a star
                         bool poweredDown = false;
                         // Hit them, powerdown them
-                        marioB->FacingRight = !fromRight;
+                        marioB->FacingRight = fromRight;
                         // powerdown must come before doknockback or it will not occur
                         if (dropStars) {
                             poweredDown = marioB->Powerdown(f, marioBEntity, false, marioAEntity);
@@ -2417,7 +2417,7 @@ namespace Quantum {
                     if (!marioAAbove) {
                         bool poweredDown = false;
                         // Hit them, powerdown them
-                        marioA->FacingRight = fromRight;
+                        marioA->FacingRight = !fromRight;
                         if (dropStars) {
                             poweredDown = marioA->Powerdown(f, marioAEntity, false, marioBEntity);
                         }


### PR DESCRIPTION
This makes the star that flies out when hitting an opponent with a blue shell while in attack mode (attack mode meaning holding X and deal damage to other players) always fly towards the Blue Sheller instead of how it is currently where it always flies AWAY from the Blue Sheller. The way it works currently makes the attack mode pretty useless as you have a very very low chance of getting the star from the player you hit due to the Blue Shell bouncing off of them, even with quick maneouvering

Before:

https://github.com/user-attachments/assets/df2d26d4-fb4a-49ce-b70c-ccbb9b6ab9b6


After:

https://github.com/user-attachments/assets/d7a45a26-18c5-4dd7-a683-d7824c97e967



In a match (current v2.1.1.0)

https://github.com/user-attachments/assets/ec34a12d-69d1-419e-9dc5-91327d75cf28

