### PR TITLE
Some Combat Adjustments

### DIFF
--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Koopa/KoopaSystem.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Koopa/KoopaSystem.cs
@@ -391,6 +391,10 @@ namespace Quantum {
 
             if (koopa->IsInShell && koopa->IsKicked) {
                 IceBlockSystem.Destroy(f, iceBlockEntity, IceBlockBreakReason.Shell, koopaEntity);
+
+                if (f.Unsafe.TryGetPointer(iceBlock->Entity, out MarioPlayer* frozenMario)) {
+                    frozenMario->Powerdown(f, iceBlock->Entity, false, koopaEntity);
+                }
             }
             return false;
         }

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Koopa/KoopaSystem.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Enemy/Koopa/KoopaSystem.cs
@@ -391,10 +391,6 @@ namespace Quantum {
 
             if (koopa->IsInShell && koopa->IsKicked) {
                 IceBlockSystem.Destroy(f, iceBlockEntity, IceBlockBreakReason.Shell, koopaEntity);
-
-                if (f.Unsafe.TryGetPointer(iceBlock->Entity, out MarioPlayer* frozenMario)) {
-                    frozenMario->Powerdown(f, iceBlock->Entity, false, koopaEntity);
-                }
             }
             return false;
         }

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/IceBlock/IceBlockSystem.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/IceBlock/IceBlockSystem.cs
@@ -137,6 +137,22 @@ namespace Quantum {
                 }
             } else if (upDot <= -Constants.PhysicsGroundMaxAngleCos) {
                 // Bottom
+                if (iceBlock->IsSliding) {
+                    var holdable = f.Unsafe.GetPointer<Holdable>(iceBlockEntity);
+                    bool dropStars = !f.Unsafe.TryGetPointer(holdable->PreviousHolder, out MarioPlayer* holderMario) || mario->GetTeam(f) != holderMario->GetTeam(f) || f.Global->Rules.TeamAttack == TeamAttackOptions.Full;
+
+                    if (!dropStars || f.Global->Rules.TeamAttack != TeamAttackOptions.None) {
+                        bool damaged = mario->DoKnockback(f, marioEntity, contact.Normal.X < 0, dropStars ? 1 : 0, KnockbackStrength.FireballBump, iceBlockEntity);
+                        if (damaged) {
+                            FPVector2 particlePos = (f.Unsafe.GetPointer<Transform2D>(marioEntity)->Position + f.Unsafe.GetPointer<Transform2D>(iceBlockEntity)->Position) / 2;
+                            f.Events.PlayKnockbackEffect(marioEntity, iceBlockEntity, KnockbackStrength.FireballBump, particlePos);
+                        }
+                    }
+
+                    Destroy(f, iceBlockEntity, IceBlockBreakReason.HitWall, marioEntity);
+                    return false;
+                }
+
                 Destroy(f, iceBlockEntity, IceBlockBreakReason.BlockBump, marioEntity);
                 return false;
             } else {

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayerSystem.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayerSystem.cs
@@ -2861,11 +2861,10 @@ namespace Quantum {
                 }
             }
 
-            bool faceAwayFromAttacker = false;
             if (f.Unsafe.TryGetPointer(attacker, out Transform2D* attackerTransform)) {
                 var marioTransform = f.Unsafe.GetPointer<Transform2D>(entity);
                 QuantumUtils.UnwrapWorldLocations(f, marioTransform->Position, attackerTransform->Position, out FPVector2 ourPos, out FPVector2 theirPos);
-                faceAwayFromAttacker = ourPos.X < theirPos.X;
+                mario->FacingRight = ourPos.X < theirPos.X;
             }
 
             bool damaged = false;
@@ -2876,20 +2875,20 @@ namespace Quantum {
             other:
                 // Weak knockback, i-frames.
                 strength = KnockbackStrength.FireballBump;
-                damaged = mario->DoKnockback(f, entity, faceAwayFromAttacker, 1, strength, attacker);
+                damaged = mario->DoKnockback(f, entity, mario->FacingRight, 1, strength, attacker);
                 mario->DamageInvincibilityFrames = Constants.DamageInvincibilityFrames;
                 break;
 
             case IceBlockBreakReason.BlockBump:
                 // Soft knockback, no i-frames.
                 strength = KnockbackStrength.Normal;
-                damaged = mario->DoKnockback(f, entity, faceAwayFromAttacker, 1, strength, attacker);
+                damaged = mario->DoKnockback(f, entity, mario->FacingRight, 1, strength, attacker);
                 break;
 
             case IceBlockBreakReason.Groundpounded:
                 // Hard knockback, i-frames.
                 strength = KnockbackStrength.Groundpound;
-                damaged = mario->DoKnockback(f, entity, faceAwayFromAttacker, 2, strength, attacker);
+                damaged = mario->DoKnockback(f, entity, mario->FacingRight, 2, strength, attacker);
                 mario->DamageInvincibilityFrames = Constants.DamageInvincibilityFrames;
                 break;
 

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayerSystem.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayerSystem.cs
@@ -2882,7 +2882,8 @@ namespace Quantum {
             case IceBlockBreakReason.BlockBump:
                 // Soft knockback, no i-frames.
                 strength = KnockbackStrength.Normal;
-                damaged = mario->DoKnockback(f, entity, mario->FacingRight, 1, strength, attacker);
+                EntityRef blockBumpOwner = f.Unsafe.TryGetPointer(attacker, out BlockBump* blockBump) ? blockBump->Owner : attacker;
+                damaged = mario->DoKnockback(f, entity, mario->FacingRight, 1, strength, blockBumpOwner);
                 break;
 
             case IceBlockBreakReason.Groundpounded:

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayerSystem.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayerSystem.cs
@@ -2883,8 +2883,7 @@ namespace Quantum {
             case IceBlockBreakReason.BlockBump:
                 // Soft knockback, no i-frames.
                 strength = KnockbackStrength.Normal;
-                EntityRef blockBumpOwner = f.Unsafe.TryGetPointer(attacker, out BlockBump* blockBump) ? blockBump->Owner : attacker;
-                damaged = mario->DoKnockback(f, entity, faceAwayFromAttacker, 1, strength, blockBumpOwner);
+                damaged = mario->DoKnockback(f, entity, faceAwayFromAttacker, 1, strength, attacker);
                 break;
 
             case IceBlockBreakReason.Groundpounded:

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayerSystem.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayerSystem.cs
@@ -2859,12 +2859,13 @@ namespace Quantum {
                 } else if (iceBlockPhysicsObject->IsTouchingRightWall) {
                     mario->FacingRight = false;
                 }
-            } else {
-                if (f.Unsafe.TryGetPointer(attacker, out Transform2D* attackerTransform)) {
-                    var marioTransform = f.Unsafe.GetPointer<Transform2D>(entity);
-                    QuantumUtils.UnwrapWorldLocations(f, marioTransform->Position, attackerTransform->Position, out FPVector2 ourPos, out FPVector2 theirPos);
-                    mario->FacingRight = ourPos.X < theirPos.X;
-                }
+            }
+
+            bool faceAwayFromAttacker = false;
+            if (f.Unsafe.TryGetPointer(attacker, out Transform2D* attackerTransform)) {
+                var marioTransform = f.Unsafe.GetPointer<Transform2D>(entity);
+                QuantumUtils.UnwrapWorldLocations(f, marioTransform->Position, attackerTransform->Position, out FPVector2 ourPos, out FPVector2 theirPos);
+                faceAwayFromAttacker = ourPos.X < theirPos.X;
             }
 
             bool damaged = false;
@@ -2875,7 +2876,7 @@ namespace Quantum {
             other:
                 // Weak knockback, i-frames.
                 strength = KnockbackStrength.FireballBump;
-                damaged = mario->DoKnockback(f, entity, mario->FacingRight, 1, strength, attacker);
+                damaged = mario->DoKnockback(f, entity, faceAwayFromAttacker, 1, strength, attacker);
                 mario->DamageInvincibilityFrames = Constants.DamageInvincibilityFrames;
                 break;
 
@@ -2883,13 +2884,13 @@ namespace Quantum {
                 // Soft knockback, no i-frames.
                 strength = KnockbackStrength.Normal;
                 EntityRef blockBumpOwner = f.Unsafe.TryGetPointer(attacker, out BlockBump* blockBump) ? blockBump->Owner : attacker;
-                damaged = mario->DoKnockback(f, entity, mario->FacingRight, 1, strength, blockBumpOwner);
+                damaged = mario->DoKnockback(f, entity, faceAwayFromAttacker, 1, strength, blockBumpOwner);
                 break;
 
             case IceBlockBreakReason.Groundpounded:
                 // Hard knockback, i-frames.
                 strength = KnockbackStrength.Groundpound;
-                damaged = mario->DoKnockback(f, entity, mario->FacingRight, 2, strength, attacker);
+                damaged = mario->DoKnockback(f, entity, faceAwayFromAttacker, 2, strength, attacker);
                 mario->DamageInvincibilityFrames = Constants.DamageInvincibilityFrames;
                 break;
 

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayerSystem.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayerSystem.cs
@@ -833,6 +833,8 @@ namespace Quantum {
             if (!mario->IsInShell && !mario->IsSliding && !mario->IsSkidding && !mario->IsInKnockback && !mario->IsTurnaround) {
                 if (rightOrLeft) {
                     mario->FacingRight = inputs.Right.IsDown;
+                } else if (!physicsObject->IsTouchingGround && (mario->IsPropellerFlying || mario->IsSpinnerFlying) && FPMath.Abs(physicsObject->Velocity.X) > FP._0_05) {
+                    mario->FacingRight = physicsObject->Velocity.X > 0;
                 }
             } else if (mario->MegaMushroomStartFrames == 0 && mario->MegaMushroomEndFrames == 0 && !mario->IsSkidding && !mario->IsTurnaround) {
                 if (!mario->IsInShell && ((FPMath.Abs(physicsObject->Velocity.X) < FP._0_50 && mario->IsCrouching) || physicsObject->IsOnSlipperyGround) && rightOrLeft) {

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayerSystem.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayerSystem.cs
@@ -2401,7 +2401,6 @@ namespace Quantum {
                         // transitions use this bool to make them lose a star
                         bool poweredDown = false;
                         // Hit them, powerdown them
-                        marioB->FacingRight = !fromRight;
                         // powerdown must come before doknockback or it will not occur
                         if (dropStars) {
                             poweredDown = marioB->Powerdown(f, marioBEntity, false, marioAEntity);
@@ -2417,7 +2416,6 @@ namespace Quantum {
                     if (!marioAAbove) {
                         bool poweredDown = false;
                         // Hit them, powerdown them
-                        marioA->FacingRight = fromRight;
                         if (dropStars) {
                             poweredDown = marioA->Powerdown(f, marioAEntity, false, marioBEntity);
                         }


### PR DESCRIPTION
- Ice blocks can now knockback players if hit from above.
- Adjusted defender's facing directions inconsitencies with:
1. Frozen & groundpounded (Defender would face attacker even if groundpounded from behind).
2. Propeller flying defender & any attack (Before they couldn't control their face direction while flying with propeller. Now it's based on inputs. Ex.: Holding left = facing left. Or else it's based on momentum. Ex.: moving right = facing right).
3. Spinning Blueshell hit (Defender would face attacker even if hit from behind).