### PR TITLE
Blue Shell Last Attacker

### DIFF
--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayerSystem.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayerSystem.cs
@@ -2423,10 +2423,10 @@ namespace Quantum {
                 }
 
                 // Crouched in shell stomps
-                if (marioA->IsCrouchedInShell && marioBAbove && !marioB->IsGroundpoundActive && !marioB->IsDrilling && marioB->CurrentPowerupState != PowerupState.MegaMushroom) {
+                if (marioA->IsCrouchedInShell && marioB->LastAttacker != marioAEntity && marioBAbove && !marioB->IsGroundpoundActive && !marioB->IsDrilling && marioB->CurrentPowerupState != PowerupState.MegaMushroom) {
                     MarioMarioBlueShellStomp(f, stage, marioBEntity, marioAEntity, fromRight);
                     return;
-                } else if (marioB->IsCrouchedInShell && marioAAbove && !marioA->IsGroundpoundActive && !marioA->IsDrilling && marioA->CurrentPowerupState != PowerupState.MegaMushroom) {
+                } else if (marioB->IsCrouchedInShell && marioA->LastAttacker != marioBEntity && marioAAbove && !marioA->IsGroundpoundActive && !marioA->IsDrilling && marioA->CurrentPowerupState != PowerupState.MegaMushroom) {
                     MarioMarioBlueShellStomp(f, stage, marioAEntity, marioBEntity, fromRight);
                     return;
                 }


### PR DESCRIPTION
Makes players in knockback unable to land on players crouched in blue shell if the blue sheller was their last attacker making it consistent with other knockback and making interactions less glitchy looking