### PR TITLE
Make powerUPs now flash 3 seconds before disappearing instead of 1

### DIFF
--- a/Assets/Scripts/Entity/Powerup/CoinItemAnimator.cs
+++ b/Assets/Scripts/Entity/Powerup/CoinItemAnimator.cs
@@ -139,7 +139,8 @@ namespace NSMB.Entities.CoinItems {
         }
 
         private void HandleDespawningBlinking(CoinItem* coinItem) {
-            if (coinItem->Lifetime <= 60) {
+            float despawnTimeRemaining = coinItem->Lifetime / 60f;
+            if (despawnTimeRemaining < 3) {
                 renderer.enabled = ((coinItem->Lifetime / 60f * blinkingRate) % 1) > 0.5f;
             }
         }


### PR DESCRIPTION
This matches with the coin disappearance flickering with those also flickering 3 seconds before disappearing

https://github.com/user-attachments/assets/6eafff07-914a-4981-bc5d-be29f5a5d01e

