### PR TITLE
Optimized LiquidAnimator.cs Performance

### DIFF
--- a/Assets/Scripts/Entity/World Elements/LiquidAnimator.cs
+++ b/Assets/Scripts/Entity/World Elements/LiquidAnimator.cs
@@ -122,15 +122,15 @@ namespace NSMB.Entities.World {
                 float height = pointHeights[i];
                 pointVelocities[i] += tension * -height;
                 pointVelocities[i] *= damping;
-            }
-            for (int i = 0; i < totalPoints; i++) {
                 pointHeights[i] += pointVelocities[i] * delta;
             }
+            float kconstXDelta = kconstant * delta;
+
             for (int i = 0; i < totalPoints; i++) {
                 float height = pointHeights[i];
 
-                pointVelocities[i] -= kconstant * delta * (height - pointHeights[(i + totalPoints - 1) % totalPoints]); // Left
-                pointVelocities[i] -= kconstant * delta * (height - pointHeights[(i + totalPoints + 1) % totalPoints]); // Right
+                pointVelocities[i] -= kconstXDelta * (height - pointHeights[(i + totalPoints - 1) % totalPoints]); // Left
+                pointVelocities[i] -= kconstXDelta * (height - pointHeights[(i + totalPoints + 1) % totalPoints]); // Right
             }
             for (int i = 0; i < totalPoints; i++) {
                 byte newR = (byte) (Mathf.Clamp01((pointHeights[i] / 20f) + 0.5f) * 255f);

--- a/Assets/Scripts/Entity/World Elements/LiquidAnimator.cs
+++ b/Assets/Scripts/Entity/World Elements/LiquidAnimator.cs
@@ -126,11 +126,14 @@ namespace NSMB.Entities.World {
             }
             float kconstXDelta = kconstant * delta;
 
+            int totalPointsM1 = totalPoints - 1;
+            int totalPointsP1 = totalPoints + 1;
+
             for (int i = 0; i < totalPoints; i++) {
                 float height = pointHeights[i];
 
-                pointVelocities[i] -= kconstXDelta * (height - pointHeights[(i + totalPoints - 1) % totalPoints]); // Left
-                pointVelocities[i] -= kconstXDelta * (height - pointHeights[(i + totalPoints + 1) % totalPoints]); // Right
+                pointVelocities[i] -= kconstXDelta * (height - pointHeights[(i + totalPointsM1) % totalPoints]); // Left
+                pointVelocities[i] -= kconstXDelta * (height - pointHeights[(i + totalPointsP1) % totalPoints]); // Right
             }
             for (int i = 0; i < totalPoints; i++) {
                 byte newR = (byte) (Mathf.Clamp01((pointHeights[i] / 20f) + 0.5f) * 255f);


### PR DESCRIPTION
Looking at LiquidAnimator.cs, there are two relatively simple optimizations I saw that could be made. One of which was caching the kconstant * delta operation in the third for loop, since that would be the same across all iterations of the loop. In CustomJungle, the number of TotalPoints is 512 when adding a _Debug.Log(totalPoints)_ under the _Initialize(int width, FP height)_ function. This means that kconstant * delta would be done 512 times per FixedUpdate instead of once.

The second was the removal of the second for loop. Since the line _pointHeights[i] += pointVelocities[i] * delta_ doesn't depend on future indices of either array, it doesn't make sense to create another for loop.

Testing this on CustomJungle, I started recording immediately after the POP sound played and recorded for about 2600 frames (according to the center number) to get a decent length of mean and stddev values. Here are the screenshots from those times:

<img width="1215" height="427" alt="Before_Changes" src="https://github.com/user-attachments/assets/39b2c31a-7575-4364-b622-9625180f735c" />
Before Changes (MEAN: 0.2898ms || STDDEV: 0.1416ms)

<img width="1225" height="321" alt="After_Removal_2nd Loop and caching kconstant" src="https://github.com/user-attachments/assets/fa8d898c-0354-4f34-90df-22b3b11abc36" />
After Changes (MEAN: 0.2858ms || STDDEV: 0.0405 ms)

While there was only a 1.3802% reduction in the mean from before to after, there was a 71.3983% reduction in the stddev.

My only assumption as to why this happens to decrease the stddev so much is mainly due to the first change. Since it was previously calling two variables in the for loop (one of which wasn't local), it would likely need to go further into memory to gather the value. Caching the operation doesn't change much in the raw performance (it's only two multiplication operations), but does make cases where it needs to fetch the cached value much more consistent since the value it's gathering is closer to where it's used (likely hits the CPU cache more often).

This WAS were I was going to stop, but then I noticed there were two other operations in the same boat as the kconstant change I made (_totalPoints + 1 _and_ totalPoints - 1_). I was initially thinking that would be overkill, but I made the change anyways and ran a test.

<img width="1224" height="426" alt="After_Caching_TPAS1" src="https://github.com/user-attachments/assets/d9ffa315-4aef-4c5f-a064-f01039507eb9" />
Total Points Operations Caching: (MEAN: 0.2843 ms || STDDEV: 0.0385 ms)

This is another negligable change on the MEAN, but a 4.93827% reduction from the changes I had already made (not a whole lot, but 5% is certainly better than the MEAN changes). These three changes combined result in a 72.8107% reduction in the standard deviation, and a 1.8978% reduction in MEAN performance on Jungle. 