### PR TITLE
Remove Redundant isInKnockback Checks in HandleFacingDirection function

### DIFF
--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayerSystem.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayerSystem.cs
@@ -838,7 +838,7 @@ namespace Quantum {
             ref var inputs = ref filter.Inputs;
             bool rightOrLeft = (inputs.Right.IsDown ^ inputs.Left.IsDown);
 
-            if (!mario->IsInShell && !mario->IsSliding && !mario->IsSkidding && !mario->IsInKnockback && !mario->IsTurnaround) {
+            if (!mario->IsInShell && !mario->IsSliding && !mario->IsSkidding && !mario->IsTurnaround) {
                 if (rightOrLeft) {
                     mario->FacingRight = inputs.Right.IsDown;
                 } else if (!physicsObject->IsTouchingGround && (mario->IsPropellerFlying || mario->IsSpinnerFlying) && FPMath.Abs(physicsObject->Velocity.X) > FP._0_05) {
@@ -847,7 +847,7 @@ namespace Quantum {
             } else if (mario->MegaMushroomStartFrames == 0 && mario->MegaMushroomEndFrames == 0 && !mario->IsSkidding && !mario->IsTurnaround) {
                 if (!mario->IsInShell && ((FPMath.Abs(physicsObject->Velocity.X) < FP._0_50 && mario->IsCrouching) || physicsObject->IsOnSlipperyGround) && rightOrLeft) {
                     mario->FacingRight = inputs.Right.IsDown;
-                } else if (mario->IsInKnockback || (physicsObject->IsTouchingGround && mario->CurrentPowerupState != PowerupState.MegaMushroom && FPMath.Abs(physicsObject->Velocity.X) > FP._0_05 && !mario->IsCrouching)) {
+                } else if ((physicsObject->IsTouchingGround && mario->CurrentPowerupState != PowerupState.MegaMushroom && FPMath.Abs(physicsObject->Velocity.X) > FP._0_05 && !mario->IsCrouching)) {
                     mario->FacingRight = physicsObject->Velocity.X > 0;
                 } else if ((!mario->IsInShell || mario->MegaMushroomStartFrames > 0) && rightOrLeft) {
                     mario->FacingRight = inputs.Right.IsDown;


### PR DESCRIPTION
In the HandleFacingDirection function inside of MarioPlayerSystem, there are three if statements that use the mario->IsInKnockback bool. The second checks do not need to be performed. This is because of the first if  statement on line 827. Since this if check ends in a return statement if the IsInKnockback value is true, that means that the rest of HandleFacingDirection would only be ran if IsInKnockback is false.

The second if statement on line 841 uses the ! operator on the IsInKnockback bool, thus making it always be true. This means that the other bools evaluated in the if statement are the deciding factors, as IsInKnockback will be the same. Removing it doesn't change the resulting check.

The third if statement on Line 850 is in the same boat, as the || operator means that if one of the two sides of the if statement are true, the whole statement is true. Since IsInKnockback will always be the same value, we can remove it from the check as only the second half changes.