### PR TITLE
Move Projectile Settings

### DIFF
--- a/Assets/QuantumUser/Resources/AssetObjects/Items/FireFlower.asset
+++ b/Assets/QuantumUser/Resources/AssetObjects/Items/FireFlower.asset
@@ -28,6 +28,8 @@ MonoBehaviour:
   BlockSpawnSoundEffect: 69
   Flags: 19
   MaxNumberOfItems: 0
+  CanSpawnAfterSeconds:
+    RawValue: 0
   TranslationKey: coinitem.fireflower
   CameraSpawnOffset:
     X:
@@ -79,4 +81,7 @@ MonoBehaviour:
   ItemPriority: 2
   EnterReserveIfOverridden: 1
   Instant: 0
+  ProjectileAsset:
+    Id:
+      Value: 503653222628643586
   SfxOverrides: []

--- a/Assets/QuantumUser/Resources/AssetObjects/Items/HammerSuit.asset
+++ b/Assets/QuantumUser/Resources/AssetObjects/Items/HammerSuit.asset
@@ -28,6 +28,8 @@ MonoBehaviour:
   BlockSpawnSoundEffect: 69
   Flags: 23
   MaxNumberOfItems: 0
+  CanSpawnAfterSeconds:
+    RawValue: 0
   TranslationKey: coinitem.hammersuit
   CameraSpawnOffset:
     X:
@@ -78,4 +80,7 @@ MonoBehaviour:
   ItemPriority: 2
   EnterReserveIfOverridden: 1
   Instant: 0
+  ProjectileAsset:
+    Id:
+      Value: 395779911797546411
   SfxOverrides: []

--- a/Assets/QuantumUser/Resources/AssetObjects/Items/IceFlower.asset
+++ b/Assets/QuantumUser/Resources/AssetObjects/Items/IceFlower.asset
@@ -28,6 +28,8 @@ MonoBehaviour:
   BlockSpawnSoundEffect: 69
   Flags: 23
   MaxNumberOfItems: 0
+  CanSpawnAfterSeconds:
+    RawValue: 0
   TranslationKey: coinitem.iceflower
   CameraSpawnOffset:
     X:
@@ -78,4 +80,7 @@ MonoBehaviour:
   ItemPriority: 2
   EnterReserveIfOverridden: 1
   Instant: 0
+  ProjectileAsset:
+    Id:
+      Value: 382315898571462450
   SfxOverrides: []

--- a/Assets/QuantumUser/Resources/AssetObjects/Projectile/FireballProjectile.asset
+++ b/Assets/QuantumUser/Resources/AssetObjects/Projectile/FireballProjectile.asset
@@ -33,6 +33,10 @@ MonoBehaviour:
   InheritShooterVelocity: 0
   HasCollision: 1
   DoesntEffectBlueShell: 1
+  MaxProjectiles: 6
+  ProjectileVolleySize: 2
+  ProjectileDelayFrames: 6
+  ProjectileVolleyFrames: 75
   DestroyParticleEffect: 5
   ShootSound: 44
   SfxOverrides: []

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayerSystem.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayerSystem.cs
@@ -1496,15 +1496,24 @@ namespace Quantum {
                     return;
                 }
 
+                var powerupAsset = QuantumUtils.FindPowerupAsset(f, mario->CurrentPowerupState);
+                if (powerupAsset == null) {
+                    return;
+                }
+                var projectileAsset = f.FindAsset(powerupAsset.ProjectileAsset);
+                if (projectileAsset == null) {
+                    return;
+                }
+
                 byte activeProjectiles = mario->CurrentProjectiles;
-                if (activeProjectiles >= physics.MaxProjecitles) {
+                if (activeProjectiles >= projectileAsset.MaxProjectiles) {
                     return;
                 }
 
                 if (activeProjectiles < 2) {
                     // Always allow if < 2
                     mario->CurrentVolley = (byte) (activeProjectiles + 1);
-                } else if (mario->CurrentVolley < physics.ProjectileVolleySize) {
+                } else if (mario->CurrentVolley < projectileAsset.ProjectileVolleySize) {
                     // Allow in this volley
                     mario->CurrentVolley++;
                 } else {
@@ -1513,8 +1522,8 @@ namespace Quantum {
                 }
 
                 mario->CurrentProjectiles++;
-                mario->ProjectileDelayFrames = physics.ProjectileDelayFrames;
-                mario->ProjectileVolleyFrames = physics.ProjectileVolleyFrames;
+                mario->ProjectileDelayFrames = projectileAsset.ProjectileDelayFrames;
+                mario->ProjectileVolleyFrames = projectileAsset.ProjectileVolleyFrames;
 
                 Projectile* projectile;
                 if (mario->CurrentPowerupState == PowerupState.HammerSuit) {

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Powerup/PowerupAsset.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Powerup/PowerupAsset.cs
@@ -30,6 +30,8 @@ public unsafe class PowerupAsset : CoinItemAsset, ISoundOverrideProvider {
     public bool EnterReserveIfOverridden = true;
     public bool Instant = false;
 
+    public AssetRef<ProjectileAsset> ProjectileAsset;
+
     public SoundEffectOverride[] SfxOverrides;
 
     [NonSerialized] private Dictionary<SoundEffect, SoundEffectOverride> overridesDict;

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Projectile/ProjectileAsset.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Projectile/ProjectileAsset.cs
@@ -16,6 +16,11 @@ public class ProjectileAsset : AssetObject, ISoundOverrideProvider {
     public bool HasCollision = true;
     public bool DoesntEffectBlueShell = true;
 
+    public byte MaxProjectiles = 6;
+    public byte ProjectileVolleySize = 2;
+    public byte ProjectileDelayFrames = 6;
+    public byte ProjectileVolleyFrames = 75;
+
     public ParticleEffect DestroyParticleEffect = ParticleEffect.None;
     public SoundEffect ShootSound = SoundEffect.Powerup_Fireball_Shoot;
 


### PR DESCRIPTION
Projectile settings (max projectiles, cooldown, etc) were determined in mario physics, which is inconvenient if you're making power-ups that has it diferent. Moved them to be projectile asset-based instead.