### PR TITLE
Ice Flower x Jungle Fix

### DIFF
--- a/Assets/QuantumUser/Simulation/Generated/Quantum.CodeGen.Core.cs
+++ b/Assets/QuantumUser/Simulation/Generated/Quantum.CodeGen.Core.cs
@@ -3908,6 +3908,14 @@ namespace Quantum {
         return result;
       }
     }
+    /// <summary>6</summary>
+    public static FP _6_00 {
+      [MethodImpl(MethodImplOptions.AggressiveInlining)] get { 
+        FP result;
+        result.RawValue = 393216;
+        return result;
+      }
+    }
     /// <summary>0.05</summary>
     public static FP PhysicsRaycastSkin {
       [MethodImpl(MethodImplOptions.AggressiveInlining)] get { 
@@ -4018,6 +4026,8 @@ namespace Quantum {
       public const Int64 _0_73 = 47841;
       /// <summary>2.75</summary>
       public const Int64 _2_75 = 180224;
+      /// <summary>6</summary>
+      public const Int64 _6_00 = 393216;
       /// <summary>0.05</summary>
       public const Int64 PhysicsRaycastSkin = 3277;
       /// <summary>0.005</summary>

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayer.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayer.cs
@@ -575,18 +575,13 @@ namespace Quantum {
 
             KnockbackTick = f.Number;
 
-            bool forceWeak = false;
-            if (freezable->IsFrozen(f) && strength != KnockbackStrength.Normal && strength != KnockbackStrength.Groundpound) {
-                forceWeak = true;
-                KnockbackTick -= 25;
-            }
             if (strength == KnockbackStrength.FireballBump && !physicsObject->IsTouchingGround) {
                 // FacingRight = fromRight;
                 knockbackVelocity.X *= FP._0_75;
             }
 
             CurrentKnockback = strength;
-            IsInWeakKnockback = forceWeak || (CurrentPowerupState != PowerupState.MegaMushroom && (strength == KnockbackStrength.CollisionBump || (strength == KnockbackStrength.FireballBump && physicsObject->IsTouchingGround)));
+            IsInWeakKnockback = CurrentPowerupState != PowerupState.MegaMushroom && (strength == KnockbackStrength.CollisionBump || (strength == KnockbackStrength.FireballBump && physicsObject->IsTouchingGround));
 
             physicsObject->Velocity = knockbackVelocity;
             physicsObject->IsTouchingGround = false;

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayer.qtn
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayer.qtn
@@ -12,6 +12,7 @@
 #define _3_75 3.75
 #define _0_73 0.73
 #define _2_75 2.75
+#define _6_00 6.00
 
 #define DamageInvincibilityFrames 120
 

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayerSystem.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayerSystem.cs
@@ -2933,6 +2933,11 @@ namespace Quantum {
                 particlePos.Y += iceBlock->Size.Y / 2;
                 f.Events.PlayKnockbackEffect(entity, brokenIceBlock, strength, particlePos, true);
             }
+
+            var holdable = f.Unsafe.GetPointer<Holdable>(brokenIceBlock);
+            if (f.Exists(holdable->PreviousHolder)) {
+                mario->LastAttacker = holdable->PreviousHolder;
+            }
         }
 
         public void OnStageReset(Frame f, QBoolean full) {

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayerSystem.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayerSystem.cs
@@ -2876,19 +2876,18 @@ namespace Quantum {
             switch (breakReason) {
             case IceBlockBreakReason.HitWall:
             case IceBlockBreakReason.Other:
-                // No floor below:
-                if (!PhysicsObjectSystem.Raycast(f, null, hitTransform->Position, FPVector2.Down, 8, out _)) {
-                    strength = KnockbackStrength.CollisionBump;
-                    damaged = mario->DoKnockback(f, entity, hitFromRight, 1, strength, attacker);
-                    if (damaged) {
+                damaged = mario->DoKnockback(f, entity, hitFromRight, 1, strength, attacker);
+                if (damaged) {
+                    // No floor below:
+                    if (!PhysicsObjectSystem.Raycast(f, null, hitTransform->Position, FPVector2.Down, 8, out _)) {
                         // Upwards bounce and shortened knockback.
+                        strength = KnockbackStrength.CollisionBump;
                         physicsObject->Velocity.Y = Constants._6_00;
                         mario->KnockbackTick -= 15;
+                    } else {
+                        // Normal hitstun duration.
+                        strength = KnockbackStrength.FireballBump;
                     }
-                } else {
-                    // Floor below: Normal hitstun duration.
-                    strength = KnockbackStrength.FireballBump;
-                    damaged = mario->DoKnockback(f, entity, hitFromRight, 1, strength, attacker);
                 }
                 break;
 

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayerSystem.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayerSystem.cs
@@ -2871,14 +2871,25 @@ namespace Quantum {
             }
             
             bool damaged = false;
+            var hitTransform = f.Unsafe.GetPointer<Transform2D>(entity);
             KnockbackStrength strength = KnockbackStrength.Normal;
             switch (breakReason) {
             case IceBlockBreakReason.HitWall:
             case IceBlockBreakReason.Other:
-                // Weak knockback, i-frames.
-                strength = KnockbackStrength.FireballBump;
-                damaged = mario->DoKnockback(f, entity, hitFromRight, 1, strength, attacker);
-                mario->DamageInvincibilityFrames = Constants.DamageInvincibilityFrames;
+                // No floor below:
+                if (!PhysicsObjectSystem.Raycast(f, null, hitTransform->Position, FPVector2.Down, 8, out _)) {
+                    strength = KnockbackStrength.CollisionBump;
+                    damaged = mario->DoKnockback(f, entity, hitFromRight, 1, strength, attacker);
+                    if (damaged) {
+                        // Upwards bounce and shortened knockback.
+                        physicsObject->Velocity.Y = Constants._6_00;
+                        mario->KnockbackTick -= 15;
+                    }
+                } else {
+                    // Floor below: Normal hitstun duration.
+                    strength = KnockbackStrength.FireballBump;
+                    damaged = mario->DoKnockback(f, entity, hitFromRight, 1, strength, attacker);
+                }
                 break;
 
             case IceBlockBreakReason.BlockBump:

--- a/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayerSystem.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Entity/Player/MarioPlayerSystem.cs
@@ -2876,17 +2876,15 @@ namespace Quantum {
             switch (breakReason) {
             case IceBlockBreakReason.HitWall:
             case IceBlockBreakReason.Other:
+                strength = KnockbackStrength.FireballBump;
                 damaged = mario->DoKnockback(f, entity, hitFromRight, 1, strength, attacker);
                 if (damaged) {
                     // No floor below:
                     if (!PhysicsObjectSystem.Raycast(f, null, hitTransform->Position, FPVector2.Down, 8, out _)) {
                         // Upwards bounce and shortened knockback.
-                        strength = KnockbackStrength.CollisionBump;
                         physicsObject->Velocity.Y = Constants._6_00;
+                        mario->InvincibilityFrames = Constants.DamageInvincibilityFrames;
                         mario->KnockbackTick -= 15;
-                    } else {
-                        // Normal hitstun duration.
-                        strength = KnockbackStrength.FireballBump;
                     }
                 }
                 break;


### PR DESCRIPTION
This PR (partially) fixes Ice Flower being OP in Jungle once for all.

The method it does is it checks if there isn't floor below via Raycast, and if so, the victim is given an upwards bounce with reduced KB time, enough to walljump out. Otherwise the knockback length will be default.