### PR TITLE
Add Lightbar Support for Playstation Controllers

### DIFF
--- a/Assets/Resources/Static/GlobalController.prefab
+++ b/Assets/Resources/Static/GlobalController.prefab
@@ -20299,6 +20299,7 @@ GameObject:
   - component: {fileID: 6114239374411719935}
   - component: {fileID: 405963795238578845}
   - component: {fileID: 5858149666679547523}
+  - component: {fileID: 4257129773049029738}
   m_Layer: 0
   m_Name: GlobalController
   m_TagString: Untagged
@@ -20417,6 +20418,7 @@ MonoBehaviour:
   controlsAutoSprint: 0
   controlsPropellerJump: 0
   controlsAllowGroundpoundWithLeftRight: 0
+  lightBarManager: {fileID: 4257129773049029738}
   miscFilterFullRooms: 0
   miscFilterInProgressRooms: 0
   miscFilterAddons: 0
@@ -20677,6 +20679,18 @@ AudioListener:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4938254683282774592}
   m_Enabled: 1
+--- !u!114 &4257129773049029738
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4938254683282774592}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ec44790a9e2cfd74b9003936c0e1c8fd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::PSLightbarManager
 --- !u!1 &4947824015881995125
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/PSLightbarManager.cs
+++ b/Assets/Scripts/PSLightbarManager.cs
@@ -1,0 +1,29 @@
+using UnityEngine;
+using UnityEngine.InputSystem.DualShock;
+
+public class PSLightbarManager : MonoBehaviour {
+
+    public Color[] colorArray = { Color.red, Color.green };
+
+    public void Start()
+    {
+        SetLightbarColor(NSMB.Settings.Instance.lightBarColorIndex);
+    }
+    public void SetLightbarColor(int lightBarColorIndex)
+    {
+        DualShockGamepad psController = DualShockGamepad.current;
+        if (psController != null) {
+            psController.SetLightBarColor(colorArray[lightBarColorIndex]);
+        }
+    }
+
+    public void ClearLightbarColor()
+    {
+        DualShockGamepad psController = DualShockGamepad.current;
+        if (psController != null)
+        {
+            psController.SetLightBarColor(Color.clear);
+        }
+    }
+
+}

--- a/Assets/Scripts/PSLightbarManager.cs.meta
+++ b/Assets/Scripts/PSLightbarManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ec44790a9e2cfd74b9003936c0e1c8fd

--- a/Assets/Scripts/Settings.cs
+++ b/Assets/Scripts/Settings.cs
@@ -239,6 +239,9 @@ namespace NSMB {
         public RumbleManager.RumbleSetting controlsRumble;
         public bool controlsFireballSprint, controlsAutoSprint, controlsPropellerJump, controlsAllowGroundpoundWithLeftRight;
 
+        public PSLightbarManager lightBarManager;
+        public int lightBarColorIndex;
+
         public bool miscFilterFullRooms, miscFilterInProgressRooms, miscFilterAddons;
 
         //---Private Variables
@@ -310,6 +313,9 @@ namespace NSMB {
             PlayerPrefs.SetInt("Controls_Rumble", (int) controlsRumble);
             PlayerPrefs.SetInt("Controls_AllowGroundpoundWithLeftRight", controlsAllowGroundpoundWithLeftRight ? 1 : 0);
             PlayerPrefs.SetString("Controls_Bindings", ControlsBindings);
+
+            //Lightbar
+            PlayerPrefs.SetInt("LightBarColorIndex", lightBarColorIndex);
 
             // Misc
             PlayerPrefs.SetInt("Misc_FilterFullRooms", miscFilterFullRooms ? 1 : 0);
@@ -469,6 +475,9 @@ namespace NSMB {
             // Generic
             TryGetSetting("General_Character", ref generalCharacter);
             TryGetSetting("General_Palette", ref generalPalette);
+
+            //Lightbar
+            TryGetSetting("LightBarColorIndex", ref lightBarColorIndex);
         }
 
         private bool TryGetSetting<T>(string key, string propertyName) {

--- a/Assets/Scripts/UI/MainMenu/InRoom/Profile/CharacterChooser.cs
+++ b/Assets/Scripts/UI/MainMenu/InRoom/Profile/CharacterChooser.cs
@@ -103,6 +103,13 @@ namespace NSMB.UI.MainMenu.Submenus.InRoom {
             ChangeCharacterButton(selectedCharacter);
 
             Settings.Instance.generalCharacter = selectedCharacter;
+
+            if(QuantumUnityDB.TryGetGlobalAsset(selectedCharacter, out var character))
+            {
+                Settings.Instance.lightBarColorIndex = character.Order;
+                Settings.Instance.lightBarManager.SetLightbarColor(character.Order);
+            }
+
             Settings.Instance.SaveSettings();
             canvas.PlayConfirmSound();
 

--- a/Assets/Scripts/UI/MainMenu/Main/MainSubmenu.cs
+++ b/Assets/Scripts/UI/MainMenu/Main/MainSubmenu.cs
@@ -34,6 +34,8 @@ namespace NSMB.UI.MainMenu.Submenus {
             }
 
             float duration = playedSounds.Max(ac => ac.length);
+            //Set Lightbar to Clear so the player color doesn't stay after application closes
+            Settings.Instance.lightBarManager.ClearLightbarColor();
             yield return new WaitForSecondsRealtime(duration);
 
 #if UNITY_EDITOR


### PR DESCRIPTION
When I was testing builds in the Unity Editor, I noticed something with my PS5 controller, it was dim. No color, no lights, nothing. That's when I got the idea for this PR: Lightbar colors based on which brother you select.

When you select Mario or Luigi on the character selection screen, it sets your Playstation Lightbar color to red or green respectively. When you press the quit button to leave the game, the lightbar gets set to clear as to not have the color persist after the game closes. The game also sets your controller to the correct brother color upon the game booting up, so now you know which brother is currently selected before even entering a lobby.

I confirmed this works with both my PS5 and PS4 controllers.