### PR TITLE
Lightbar Support w/ 5 options

### DIFF
--- a/Assets/QuantumUser/Resources/AssetObjects/Characters/LuigiCharacter.asset
+++ b/Assets/QuantumUser/Resources/AssetObjects/Characters/LuigiCharacter.asset
@@ -30,9 +30,17 @@ MonoBehaviour:
   SilhouetteSprite: {fileID: 21300000, guid: 69ebf16f7ccd5c34fb0733a2b65e900f, type: 3}
   SelectionSprite: {fileID: 1263302900, guid: 66a50f8ce62e8954a977cf86df786637, type: 3}
   SelectionColor: {r: 0.401459, g: 0.9716981, b: 0.3254272, a: 1}
-  SelectionOrder: -1000
-  SmallOverrides: {fileID: 22100000, guid: a1854453357bb034e89ec419b0f57906, type: 2}
-  LargeOverrides: {fileID: 22100000, guid: 671e2adc5dbd26a45abdf5c18398a86e, type: 2}
+  lightBarColors:
+  - {r: 0, g: 1, b: 0, a: 1}
+  - {r: 0.23529412, g: 0.78431374, b: 1, a: 1}
+  - {r: 0, g: 1, b: 0, a: 1}
+  - {r: 1, g: 0.39215687, b: 0, a: 1}
+  - {r: 0, g: 0.5882353, b: 1, a: 1}
+  - {r: 0.32941177, g: 0.12941177, b: 0, a: 1}
+  - {r: 0, g: 0, b: 1, a: 1}
+  - {r: 0.09803922, g: 0.09803922, b: 0.09803922, a: 1}
+  - {r: 0, g: 1, b: 0, a: 1}
+  - {r: 1, g: 1, b: 0, a: 1}
   Order: 1
   SfxOverrides:
   - SoundEffect: 33

--- a/Assets/QuantumUser/Resources/AssetObjects/Characters/MarioCharacter.asset
+++ b/Assets/QuantumUser/Resources/AssetObjects/Characters/MarioCharacter.asset
@@ -30,9 +30,16 @@ MonoBehaviour:
   SilhouetteSprite: {fileID: 21300000, guid: e52d82a4d5d0ae845bb4726a3600bc62, type: 3}
   SelectionSprite: {fileID: -1589787217, guid: 66a50f8ce62e8954a977cf86df786637, type: 3}
   SelectionColor: {r: 0.8867924, g: 0.23843002, b: 0.23843002, a: 1}
-  SelectionOrder: -2000
-  SmallOverrides: {fileID: 22100000, guid: 347b7f77a47c4db4b85584fbfdecf63b, type: 2}
-  LargeOverrides: {fileID: 9100000, guid: fa2b2fc953f5f444291d26193e0ac7fb, type: 2}
+  lightBarColors:
+  - {r: 1, g: 0, b: 0, a: 1}
+  - {r: 0.23529412, g: 0.78431374, b: 1, a: 1}
+  - {r: 1, g: 0, b: 0, a: 1}
+  - {r: 1, g: 0.39215687, b: 0, a: 1}
+  - {r: 0, g: 0.5882353, b: 1, a: 1}
+  - {r: 0.32941177, g: 0.12941177, b: 0, a: 1}
+  - {r: 0, g: 0, b: 1, a: 1}
+  - {r: 0.09803922, g: 0.09803922, b: 0.09803922, a: 1}
+  - {r: 1, g: 0, b: 0, a: 1}
+  - {r: 1, g: 1, b: 0, a: 1}
   Order: 0
-  IsLegacy: 1
   SfxOverrides: []

--- a/Assets/QuantumUser/Simulation/NSMB/Room/CharacterAsset.cs
+++ b/Assets/QuantumUser/Simulation/NSMB/Room/CharacterAsset.cs
@@ -21,6 +21,7 @@ public class CharacterAsset : AssetObject, ISoundOverrideProvider, IOrderedAsset
 
     public Sprite SelectionSprite;
     public Color SelectionColor = Color.white;
+    public Color[] lightBarColors = new Color[10];
 #endif
 
     public int Order;

--- a/Assets/Resources/Static/GlobalController.prefab
+++ b/Assets/Resources/Static/GlobalController.prefab
@@ -2543,6 +2543,180 @@ MonoBehaviour:
   m_FlexibleWidth: 1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
+--- !u!1 &549964654077754092
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 115874109366884332}
+  - component: {fileID: 9132537730608499663}
+  - component: {fileID: 6833638242432392391}
+  - component: {fileID: 8019152977274905840}
+  - component: {fileID: 3528028029290177329}
+  - component: {fileID: 4762511059534229765}
+  m_Layer: 16
+  m_Name: ArrowLeft
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &115874109366884332
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 549964654077754092}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5959518006385058824}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: 40}
+  m_Pivot: {x: 0, y: 0.5}
+--- !u!222 &9132537730608499663
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 549964654077754092}
+  m_CullTransparentMesh: 1
+--- !u!114 &6833638242432392391
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 549964654077754092}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: -1361643289, guid: 4953af3e17ea87e4586d634426e4eb01, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &8019152977274905840
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 549964654077754092}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 2
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 1, g: 1, b: 1, a: 1}
+    m_PressedColor: {r: 1, g: 1, b: 1, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 2070558237, guid: 4953af3e17ea87e4586d634426e4eb01,
+      type: 3}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 431117608, guid: 4953af3e17ea87e4586d634426e4eb01,
+      type: 3}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 6833638242432392391}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 7616273702463189552}
+        m_TargetAssemblyTypeName: NSMB.UI.Pause.Options.ScrollablePauseOption, Assembly-CSharp
+        m_MethodName: OnLeftPress
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 6650708626366051462}
+        m_TargetAssemblyTypeName: NSMB.UI.Options.PauseOptionMenuManager, Assembly-CSharp
+        m_MethodName: SetCurrentOption
+        m_Mode: 2
+        m_Arguments:
+          m_ObjectArgument: {fileID: 7616273702463189552}
+          m_ObjectArgumentAssemblyTypeName: NSMB.UI.Options.PauseOption, Assembly-CSharp
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &3528028029290177329
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 549964654077754092}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0b148fe25e99eb48b9724523833bab1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Delegates: []
+--- !u!114 &4762511059534229765
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 549964654077754092}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d4b43c74b8b68684abcbe13d72db54c3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  scrollOnly: 0
 --- !u!1 &564211245214427649
 GameObject:
   m_ObjectHideFlags: 0
@@ -9804,6 +9978,165 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   flipChildrenNavigation: 0
   immediateChildrenOnly: 0
+--- !u!1 &2319663253302851395
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2423042660623923181}
+  - component: {fileID: 7946985029792559330}
+  - component: {fileID: 4224535055656778918}
+  - component: {fileID: 112787585329390982}
+  m_Layer: 16
+  m_Name: Label
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2423042660623923181
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2319663253302851395}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5442515608975931596}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 285.25, y: -25}
+  m_SizeDelta: {x: 570.5, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &7946985029792559330
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2319663253302851395}
+  m_CullTransparentMesh: 1
+--- !u!114 &4224535055656778918
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2319663253302851395}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: DualShock/DualSense Lightbar Setting
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 38e8769007229044bb229d69f8cbae74, type: 2}
+  m_sharedMaterial: {fileID: 3023213983796840565, guid: 38e8769007229044bb229d69f8cbae74,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 40
+  m_fontSizeBase: 40
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 40
+  m_fontSizeMax: 40
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 50
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 1
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!114 &112787585329390982
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2319663253302851395}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: 0
+  m_MinHeight: -1
+  m_PreferredWidth: 0
+  m_PreferredHeight: -1
+  m_FlexibleWidth: 1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!1 &2348653508828997697
 GameObject:
   m_ObjectHideFlags: 0
@@ -11922,6 +12255,7 @@ MonoBehaviour:
   - {fileID: 9168185109869609887}
   - {fileID: 8894859896773873037}
   - {fileID: 4596634113779864490}
+  - {fileID: 7616273702463189552}
   image: {fileID: 3538618809577315634}
   manager: {fileID: 6650708626366051462}
   scrollPaneContent: {fileID: 1261650795489084770}
@@ -12525,7 +12859,7 @@ RectTransform:
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
-  m_SizeDelta: {x: 1148.9999, y: 644.99994}
+  m_SizeDelta: {x: 1149, y: 945.66113}
   m_Pivot: {x: 0, y: 1}
 --- !u!222 &3136341348935244609
 CanvasRenderer:
@@ -12729,6 +13063,131 @@ CanvasGroup:
   m_Interactable: 1
   m_BlocksRaycasts: 1
   m_IgnoreParentGroups: 0
+--- !u!1 &2887532368641359874
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5442515608975931596}
+  - component: {fileID: 7616273702463189552}
+  - component: {fileID: 1557948680167864694}
+  - component: {fileID: 143341425554457721}
+  - component: {fileID: 4443359491087765280}
+  m_Layer: 16
+  m_Name: ControlsLightbar
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!224 &5442515608975931596
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2887532368641359874}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 2423042660623923181}
+  - {fileID: 5959518006385058824}
+  m_Father: {fileID: 1261650795489084770}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 574.5, y: -25}
+  m_SizeDelta: {x: 1149, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &7616273702463189552
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2887532368641359874}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 396ba8eaeed1ce44ba291e8083cfd8ae, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  manager: {fileID: 6650708626366051462}
+  label: {fileID: 4224535055656778918}
+  loader: {fileID: 1557948680167864694}
+  translationKey: DualShock/DualSense Lightbar Setting
+  hideOnWebGL: 0
+  requireReconnect: 0
+  value: 0
+  options:
+  - Off
+  - Brother Color
+  - Powerup Color (Simple)
+  - Powerup Color (Blink)
+  - Slot/Team Color
+  leftButton: {fileID: 8019152977274905840}
+  rightButton: {fileID: 5594919298276806512}
+  display: {fileID: 2335284173990124118}
+  OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &1557948680167864694
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2887532368641359874}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4a2cc67e9baaf664598f544f0d069101, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  fieldName: lightBarColorSettingIndex
+--- !u!114 &143341425554457721
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2887532368641359874}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 30649d3a9faa99c48a7b1166b86bf2a0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Padding:
+    m_Left: 0
+    m_Right: 0
+    m_Top: 0
+    m_Bottom: 0
+  m_ChildAlignment: 0
+  m_Spacing: 8
+  m_ChildForceExpandWidth: 0
+  m_ChildForceExpandHeight: 1
+  m_ChildControlWidth: 1
+  m_ChildControlHeight: 1
+  m_ChildScaleWidth: 0
+  m_ChildScaleHeight: 0
+  m_ReverseArrangement: 0
+--- !u!114 &4443359491087765280
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2887532368641359874}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 816fcaa5c2c797c4da14a9d6314d38d0, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  flipChildrenNavigation: 0
+  immediateChildrenOnly: 0
 --- !u!1 &2890059247559055333
 GameObject:
   m_ObjectHideFlags: 0
@@ -12842,6 +13301,65 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   flipChildrenNavigation: 0
   immediateChildrenOnly: 0
+--- !u!1 &2899567753385833071
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5959518006385058824}
+  - component: {fileID: 717191281543011568}
+  m_Layer: 16
+  m_Name: Box
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5959518006385058824
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2899567753385833071}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 1834973032175823554}
+  - {fileID: 115874109366884332}
+  - {fileID: 5361619430062140455}
+  m_Father: {fileID: 5442515608975931596}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 863.75, y: -25}
+  m_SizeDelta: {x: 570.5, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &717191281543011568
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2899567753385833071}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 306cc8c2b49d7114eaa3623786fc2126, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_IgnoreLayout: 0
+  m_MinWidth: 0
+  m_MinHeight: -1
+  m_PreferredWidth: 0
+  m_PreferredHeight: -1
+  m_FlexibleWidth: 1
+  m_FlexibleHeight: -1
+  m_LayoutPriority: 1
 --- !u!1 &2945600681406297334
 GameObject:
   m_ObjectHideFlags: 0
@@ -15194,6 +15712,7 @@ RectTransform:
   - {fileID: 4317821690921805427}
   - {fileID: 8058117736493084757}
   - {fileID: 1319464001881629376}
+  - {fileID: 5442515608975931596}
   m_Father: {fileID: 2137978929656160409}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
@@ -20419,6 +20938,7 @@ MonoBehaviour:
   controlsPropellerJump: 0
   controlsAllowGroundpoundWithLeftRight: 0
   lightBarManager: {fileID: 4257129773049029738}
+  lightBarColorSettingIndex: 0
   miscFilterFullRooms: 0
   miscFilterInProgressRooms: 0
   miscFilterAddons: 0
@@ -20691,6 +21211,9 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: ec44790a9e2cfd74b9003936c0e1c8fd, type: 3}
   m_Name: 
   m_EditorClassIdentifier: Assembly-CSharp::PSLightbarManager
+  colorArray:
+  - {r: 1, g: 0, b: 0, a: 1}
+  - {r: 0, g: 1, b: 0, a: 1}
 --- !u!1 &4947824015881995125
 GameObject:
   m_ObjectHideFlags: 0
@@ -21273,6 +21796,110 @@ MonoBehaviour:
   m_FlexibleWidth: 0
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
+--- !u!1 &5014142935573183665
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1834973032175823554}
+  - component: {fileID: 4665537268419086335}
+  - component: {fileID: 1311117945599617709}
+  - component: {fileID: 1447030121659897848}
+  - component: {fileID: 2184982697819263178}
+  m_Layer: 16
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1834973032175823554
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5014142935573183665}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children:
+  - {fileID: 7074175702589504477}
+  m_Father: {fileID: 5959518006385058824}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -50, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &4665537268419086335
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5014142935573183665}
+  m_CullTransparentMesh: 1
+--- !u!114 &1311117945599617709
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5014142935573183665}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 332771783, guid: 4953af3e17ea87e4586d634426e4eb01, type: 3}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &1447030121659897848
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5014142935573183665}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0b148fe25e99eb48b9724523833bab1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Delegates: []
+--- !u!114 &2184982697819263178
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5014142935573183665}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d4b43c74b8b68684abcbe13d72db54c3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  scrollOnly: 0
 --- !u!1 &5016402924591457864
 GameObject:
   m_ObjectHideFlags: 0
@@ -25082,7 +25709,7 @@ RectTransform:
   m_Father: {fileID: 1994490215999569909}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 0.9999999}
+  m_AnchorMax: {x: 1, y: 1}
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 20, y: 20}
   m_Pivot: {x: 0.5, y: 0.5}
@@ -25258,6 +25885,144 @@ MonoBehaviour:
   m_FillOrigin: 0
   m_UseSpriteMesh: 0
   m_PixelsPerUnitMultiplier: 1
+--- !u!1 &6076054355239619995
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7074175702589504477}
+  - component: {fileID: 6973823583401844495}
+  - component: {fileID: 2335284173990124118}
+  m_Layer: 16
+  m_Name: Display
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &7074175702589504477
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6076054355239619995}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 1834973032175823554}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: -10, y: -10}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!222 &6973823583401844495
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6076054355239619995}
+  m_CullTransparentMesh: 1
+--- !u!114 &2335284173990124118
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6076054355239619995}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: null
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 03bd50bb8343d1d4dbb0873e4c9abb95, type: 2}
+  m_sharedMaterial: {fileID: -4437592673344618727, guid: 03bd50bb8343d1d4dbb0873e4c9abb95,
+    type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 28
+  m_fontSizeBase: 48
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 0
+  m_fontSizeMax: 28
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 512
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_characterHorizontalScale: 1
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_TextWrappingMode: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_EmojiFallbackSupport: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
 --- !u!1 &6090551485161630976
 GameObject:
   m_ObjectHideFlags: 0
@@ -31192,6 +31957,180 @@ MonoBehaviour:
   m_FlexibleWidth: 2
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
+--- !u!1 &7388207375619438461
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5361619430062140455}
+  - component: {fileID: 5403155699418826502}
+  - component: {fileID: 5296084398500821807}
+  - component: {fileID: 5594919298276806512}
+  - component: {fileID: 6506602203508418590}
+  - component: {fileID: 7966492509465200596}
+  m_Layer: 16
+  m_Name: ArrowRight
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &5361619430062140455
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7388207375619438461}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 5959518006385058824}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 20, y: 40}
+  m_Pivot: {x: 1, y: 0.5}
+--- !u!222 &5403155699418826502
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7388207375619438461}
+  m_CullTransparentMesh: 1
+--- !u!114 &5296084398500821807
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7388207375619438461}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: -1569131217, guid: 4953af3e17ea87e4586d634426e4eb01, type: 3}
+  m_Type: 0
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!114 &5594919298276806512
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7388207375619438461}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4e29b1a8efbd4b44bb3f3716e73f07ff, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 0
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 2
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 1, g: 1, b: 1, a: 1}
+    m_PressedColor: {r: 1, g: 1, b: 1, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: -1636898544, guid: 4953af3e17ea87e4586d634426e4eb01,
+      type: 3}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: -586779644, guid: 4953af3e17ea87e4586d634426e4eb01,
+      type: 3}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 1
+  m_TargetGraphic: {fileID: 5296084398500821807}
+  m_OnClick:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 7616273702463189552}
+        m_TargetAssemblyTypeName: NSMB.UI.Pause.Options.ScrollablePauseOption, Assembly-CSharp
+        m_MethodName: OnRightPress
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 6650708626366051462}
+        m_TargetAssemblyTypeName: NSMB.UI.Options.PauseOptionMenuManager, Assembly-CSharp
+        m_MethodName: SetCurrentOption
+        m_Mode: 2
+        m_Arguments:
+          m_ObjectArgument: {fileID: 7616273702463189552}
+          m_ObjectArgumentAssemblyTypeName: NSMB.UI.Options.PauseOption, Assembly-CSharp
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+--- !u!114 &6506602203508418590
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7388207375619438461}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d0b148fe25e99eb48b9724523833bab1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Delegates: []
+--- !u!114 &7966492509465200596
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7388207375619438461}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d4b43c74b8b68684abcbe13d72db54c3, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  scrollOnly: 0
 --- !u!1 &7408602943310970234
 GameObject:
   m_ObjectHideFlags: 0
@@ -35053,8 +35992,8 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 1}
   m_AnchorMax: {x: 0, y: 1}
-  m_AnchoredPosition: {x: 1188.9999, y: -322.49997}
-  m_SizeDelta: {x: 32, y: 644.99994}
+  m_AnchoredPosition: {x: 1189, y: -472.83057}
+  m_SizeDelta: {x: 32, y: 945.66113}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1604476751582959607
 MonoBehaviour:

--- a/Assets/Resources/Static/GlobalController.prefab
+++ b/Assets/Resources/Static/GlobalController.prefab
@@ -20299,6 +20299,7 @@ GameObject:
   - component: {fileID: 6114239374411719935}
   - component: {fileID: 405963795238578845}
   - component: {fileID: 5858149666679547523}
+  - component: {fileID: 4257129773049029738}
   m_Layer: 0
   m_Name: GlobalController
   m_TagString: Untagged
@@ -20417,6 +20418,7 @@ MonoBehaviour:
   controlsAutoSprint: 0
   controlsPropellerJump: 0
   controlsAllowGroundpoundWithLeftRight: 0
+  lightBarManager: {fileID: 4257129773049029738}
   miscFilterFullRooms: 0
   miscFilterInProgressRooms: 0
   miscFilterAddons: 0
@@ -20677,6 +20679,18 @@ AudioListener:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4938254683282774592}
   m_Enabled: 1
+--- !u!114 &4257129773049029738
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4938254683282774592}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ec44790a9e2cfd74b9003936c0e1c8fd, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Assembly-CSharp::PSLightbarManager
 --- !u!1 &4947824015881995125
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Entity/Player/MarioPlayerAnimator.cs
+++ b/Assets/Scripts/Entity/Player/MarioPlayerAnimator.cs
@@ -12,6 +12,7 @@ using Quantum.Profiling;
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 using UnityEngine;
 using UnityEngine.Rendering;
 using UnityEngine.Scripting;
@@ -709,6 +710,23 @@ namespace NSMB.Entities.Player {
                 teammateStompTimer -= Time.deltaTime;
             }
             modelRoot.transform.SetLossyScale(targetScale);
+
+            //Converts whatever the powerup state is to the appropriate lightbar color
+            if (Settings.Instance.lightBarColorSettingIndex > 0) {
+                //Checks if the character we're using is a local player
+                bool isLocal = PlayerElements.AllPlayerElements.Any(pe => pe.Player == mario->PlayerRef);
+                if (isLocal) {
+                    if (Settings.Instance.lightBarColorSettingIndex == (int) PSLightbarManager.ColorSettings.BrotherColor) {
+                        Settings.Instance.lightBarManager.SetLightbarColor(character.lightBarColors[0]);
+                    } else if (Settings.Instance.lightBarColorSettingIndex == (int) PSLightbarManager.ColorSettings.PowerupColorSimple) {
+                        Settings.Instance.lightBarManager.SetLightbarColor(mario->IsStarmanInvincible ? character.lightBarColors[9] : character.lightBarColors[(int) mario->CurrentPowerupState]);
+                    } else if (Settings.Instance.lightBarColorSettingIndex == (int) PSLightbarManager.ColorSettings.PowerupColorBlink) {
+                        Settings.Instance.lightBarManager.SetLightbarColor(mario->IsStarmanInvincible ? character.lightBarColors[9] : character.lightBarColors[(int) DisplayPowerupState(mario, f)]);
+                    } else if (Settings.Instance.lightBarColorSettingIndex == (int) PSLightbarManager.ColorSettings.Slot_TeamColor) {
+                        Settings.Instance.lightBarManager.SetLightbarColor(Utils.GetPlayerSlotInfo(f, mario->PlayerRef).Color);
+                    }
+                }
+            }
         }
 
         private PowerupVisuals FindPowerupVisuals(PowerupState state) {
@@ -1371,6 +1389,7 @@ namespace NSMB.Entities.Player {
                 var powerup = f.FindAsset(anim.Scriptable);
                 PlaySound(powerup.SoundEffect, new[] { powerup });
             }
+            
         }
     }
 }

--- a/Assets/Scripts/Networking/NetworkHandler.cs
+++ b/Assets/Scripts/Networking/NetworkHandler.cs
@@ -1,5 +1,6 @@
 using NSMB.Networking;
 using NSMB.Replay;
+using NSMB.UI.Game;
 using NSMB.Utilities;
 using NSMB.Utilities.Extensions;
 using Photon.Client;
@@ -403,6 +404,12 @@ namespace NSMB.Networking {
             }
 
             Debug.Log($"[Network] AddPlayer confirmed on Frame {e.Frame.Number}, {e.Player} with slot {e.PlayerSlot}");
+
+            //If our settings are set to use the lightBarSetting
+            if (Settings.Instance.lightBarColorSettingIndex == (int) PSLightbarManager.ColorSettings.Slot_TeamColor)
+            {
+                Settings.Instance.lightBarManager.SetLightbarColor(GlobalController.Instance.playerSlots[e.PlayerSlot].Color);
+            }
         }
 
         private void OnLocalPlayerAddFailed(CallbackLocalPlayerAddFailed e) {

--- a/Assets/Scripts/PSLightbarManager.cs
+++ b/Assets/Scripts/PSLightbarManager.cs
@@ -1,0 +1,29 @@
+using UnityEngine;
+using UnityEngine.InputSystem.DualShock;
+
+public class PSLightbarManager : MonoBehaviour {
+
+    public Color[] colorArray = { Color.red, Color.green };
+
+    public void Start()
+    {
+        SetLightbarColor(NSMB.Settings.Instance.lightBarColorIndex);
+    }
+    public void SetLightbarColor(int lightBarColorIndex)
+    {
+        DualShockGamepad psController = DualShockGamepad.current;
+        if (psController != null) {
+            psController.SetLightBarColor(colorArray[lightBarColorIndex]);
+        }
+    }
+
+    public void ClearLightbarColor()
+    {
+        DualShockGamepad psController = DualShockGamepad.current;
+        if (psController != null)
+        {
+            psController.SetLightBarColor(Color.clear);
+        }
+    }
+
+}

--- a/Assets/Scripts/PSLightbarManager.cs
+++ b/Assets/Scripts/PSLightbarManager.cs
@@ -1,3 +1,5 @@
+using NSMB;
+using Quantum;
 using UnityEngine;
 using UnityEngine.InputSystem.DualShock;
 
@@ -7,13 +9,18 @@ public class PSLightbarManager : MonoBehaviour {
 
     public void Start()
     {
-        SetLightbarColor(NSMB.Settings.Instance.lightBarColorIndex);
+        if (Settings.Instance.lightBarColorSettingIndex > 0)
+        {
+            QuantumUnityDB.TryGetGlobalAsset(NSMB.Settings.Instance.generalCharacter, out var character);
+
+            SetLightbarColor(character.lightBarColors[0]);
+        }
     }
-    public void SetLightbarColor(int lightBarColorIndex)
+    public void SetLightbarColor(Color lightBarColor)
     {
         DualShockGamepad psController = DualShockGamepad.current;
         if (psController != null) {
-            psController.SetLightBarColor(colorArray[lightBarColorIndex]);
+            psController.SetLightBarColor(lightBarColor);
         }
     }
 
@@ -24,6 +31,15 @@ public class PSLightbarManager : MonoBehaviour {
         {
             psController.SetLightBarColor(Color.clear);
         }
+    }
+
+    public enum ColorSettings: int
+    {
+        Off,
+        BrotherColor,
+        PowerupColorSimple,
+        PowerupColorBlink,
+        Slot_TeamColor
     }
 
 }

--- a/Assets/Scripts/PSLightbarManager.cs.meta
+++ b/Assets/Scripts/PSLightbarManager.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: ec44790a9e2cfd74b9003936c0e1c8fd

--- a/Assets/Scripts/Settings.cs
+++ b/Assets/Scripts/Settings.cs
@@ -239,6 +239,9 @@ namespace NSMB {
         public RumbleManager.RumbleSetting controlsRumble;
         public bool controlsFireballSprint, controlsAutoSprint, controlsPropellerJump, controlsAllowGroundpoundWithLeftRight;
 
+        public PSLightbarManager lightBarManager;
+        public int lightBarColorIndex;
+
         public bool miscFilterFullRooms, miscFilterInProgressRooms, miscFilterAddons;
 
         //---Private Variables
@@ -310,6 +313,9 @@ namespace NSMB {
             PlayerPrefs.SetInt("Controls_Rumble", (int) controlsRumble);
             PlayerPrefs.SetInt("Controls_AllowGroundpoundWithLeftRight", controlsAllowGroundpoundWithLeftRight ? 1 : 0);
             PlayerPrefs.SetString("Controls_Bindings", ControlsBindings);
+
+            //Lightbar
+            PlayerPrefs.SetInt("LightBarColorIndex", lightBarColorIndex);
 
             // Misc
             PlayerPrefs.SetInt("Misc_FilterFullRooms", miscFilterFullRooms ? 1 : 0);
@@ -469,6 +475,9 @@ namespace NSMB {
             // Generic
             TryGetSetting("General_Character", ref generalCharacter);
             TryGetSetting("General_Palette", ref generalPalette);
+
+            //Lightbar
+            TryGetSetting("LightBarColorIndex", ref lightBarColorIndex);
         }
 
         private bool TryGetSetting<T>(string key, string propertyName) {

--- a/Assets/Scripts/Settings.cs
+++ b/Assets/Scripts/Settings.cs
@@ -240,7 +240,7 @@ namespace NSMB {
         public bool controlsFireballSprint, controlsAutoSprint, controlsPropellerJump, controlsAllowGroundpoundWithLeftRight;
 
         public PSLightbarManager lightBarManager;
-        public int lightBarColorIndex;
+        public int lightBarColorSettingIndex;
 
         public bool miscFilterFullRooms, miscFilterInProgressRooms, miscFilterAddons;
 
@@ -315,7 +315,16 @@ namespace NSMB {
             PlayerPrefs.SetString("Controls_Bindings", ControlsBindings);
 
             //Lightbar
-            PlayerPrefs.SetInt("LightBarColorIndex", lightBarColorIndex);
+            PlayerPrefs.SetInt("LightBarColorSettingIndex", lightBarColorSettingIndex);
+
+            //This ensures the lightbar actually updates when changing the option in the Settings menu
+            if (lightBarColorSettingIndex == 0) {
+                lightBarManager.ClearLightbarColor();
+            } else if (lightBarColorSettingIndex != (int) PSLightbarManager.ColorSettings.Slot_TeamColor){
+                QuantumUnityDB.TryGetGlobalAsset(Instance.generalCharacter, out var character);
+
+                lightBarManager.SetLightbarColor(character.lightBarColors[0]);
+              }
 
             // Misc
             PlayerPrefs.SetInt("Misc_FilterFullRooms", miscFilterFullRooms ? 1 : 0);
@@ -477,7 +486,7 @@ namespace NSMB {
             TryGetSetting("General_Palette", ref generalPalette);
 
             //Lightbar
-            TryGetSetting("LightBarColorIndex", ref lightBarColorIndex);
+            TryGetSetting("LightBarColorSettingIndex", ref lightBarColorSettingIndex);
         }
 
         private bool TryGetSetting<T>(string key, string propertyName) {

--- a/Assets/Scripts/UI/MainMenu/InRoom/Profile/CharacterChooser.cs
+++ b/Assets/Scripts/UI/MainMenu/InRoom/Profile/CharacterChooser.cs
@@ -103,6 +103,13 @@ namespace NSMB.UI.MainMenu.Submenus.InRoom {
             ChangeCharacterButton(selectedCharacter);
 
             Settings.Instance.generalCharacter = selectedCharacter;
+
+            if(QuantumUnityDB.TryGetGlobalAsset(selectedCharacter, out var character))
+            {
+                Settings.Instance.lightBarColorIndex = character.Order;
+                Settings.Instance.lightBarManager.SetLightbarColor(character.Order);
+            }
+
             Settings.Instance.SaveSettings();
             canvas.PlayConfirmSound();
 

--- a/Assets/Scripts/UI/MainMenu/InRoom/Profile/CharacterChooser.cs
+++ b/Assets/Scripts/UI/MainMenu/InRoom/Profile/CharacterChooser.cs
@@ -104,10 +104,12 @@ namespace NSMB.UI.MainMenu.Submenus.InRoom {
 
             Settings.Instance.generalCharacter = selectedCharacter;
 
-            if(QuantumUnityDB.TryGetGlobalAsset(selectedCharacter, out var character))
-            {
-                Settings.Instance.lightBarColorIndex = character.Order;
-                Settings.Instance.lightBarManager.SetLightbarColor(character.Order);
+            //Sets the bar color to the player
+            if (Settings.Instance.lightBarColorSettingIndex > 0 && Settings.Instance.lightBarColorSettingIndex != (int) PSLightbarManager.ColorSettings.Slot_TeamColor) {
+                if (QuantumUnityDB.TryGetGlobalAsset(selectedCharacter, out var character)) {
+                    Settings.Instance.lightBarManager.SetLightbarColor(character.lightBarColors[0]);
+                    Debug.Log("Called this function");
+                }
             }
 
             Settings.Instance.SaveSettings();

--- a/Assets/Scripts/UI/MainMenu/InRoom/Profile/TeamChooser.cs
+++ b/Assets/Scripts/UI/MainMenu/InRoom/Profile/TeamChooser.cs
@@ -178,7 +178,17 @@ namespace NSMB.UI.MainMenu.Submenus.InRoom {
             if (f.Global->Rules.TeamsEnabled) {
                 var teams = f.Context.GetAllAssets<TeamAsset>();
                 TeamAsset team = teams[selected % teams.Count];
+                if (Settings.Instance.lightBarColorSettingIndex == (int) PSLightbarManager.ColorSettings.Slot_TeamColor) {
+                    Settings.Instance.lightBarManager.SetLightbarColor(team.color);
+                }
                 flag.sprite = Settings.Instance.GraphicsColorblind ? team.spriteColorblind : team.spriteNormal;
+            } else
+            {
+                if (Settings.Instance.lightBarColorSettingIndex == (int) PSLightbarManager.ColorSettings.Slot_TeamColor) {
+                    var localSlots = QuantumRunner.DefaultGame.GetLocalPlayerSlots();
+                    int slot = localSlots[0];
+                    Settings.Instance.lightBarManager.SetLightbarColor(GlobalController.Instance.playerSlots[0].Color);
+                }
             }
         }
     }

--- a/Assets/Scripts/UI/MainMenu/Main/MainSubmenu.cs
+++ b/Assets/Scripts/UI/MainMenu/Main/MainSubmenu.cs
@@ -34,6 +34,8 @@ namespace NSMB.UI.MainMenu.Submenus {
             }
 
             float duration = playedSounds.Max(ac => ac.length);
+            //Set Lightbar to Clear so the player color doesn't stay after application closes
+            Settings.Instance.lightBarManager.ClearLightbarColor();
             yield return new WaitForSecondsRealtime(duration);
 
 #if UNITY_EDITOR


### PR DESCRIPTION
This pull requests adds Dualsense/Dualshock Lightbar support to the game. There are 5 options available with this request:


Off
Brother Color
Powerup (Simple)
Powerup (Blink)
Slot/Team Color

This also adds a 10 index ColorArray to the character asset scriptable object type, with each index corresponding to the following values:

0 - No Powerup (used for the brother color)
1 - Mini Mushroom
2 - Mushroom
3 - Fire Flower
4 - Ice Flower
5 - Propeller Mushroom
6 - Blue Shell
7 - Hammer Suit
8 - Mega Mushroom
9 - Invincible/Starman

Brother Color is straight forward. It just chooses the color at the 0 index of the color array (which is set to red/green respectively). The Powerup Colors use the respective indices in the array to set the lightbar color. The only difference between Simple and Blink is whether the lightbar blinks upon gaining/losing a powerup. Slot/Team Color sets the lightbar to either the color of your index in the PlayerSlot list OR your current team color.